### PR TITLE
Add workflow to measure coverage.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
         run: sudo apt-get install lcov
 
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: mach | Build
         uses: ./.github/actions/mach_build
@@ -64,7 +64,6 @@ jobs:
       - name: Generate reports
         run: |
           export PATH=/usr/lib/llvm-11/bin:$PATH
-          chmod +x ./tools/coverage.sh
           ./tools/coverage.sh
 
       - name: Coveralls

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,74 @@
+name: Test Coveralls
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .gitignore
+      - CLA.md
+      - CODE_OF_CONDUCT.md
+      - CONTRIBUTING.md
+      - cpu-features.md
+      - LICENSE
+      - LICENSE-APACHE
+      - README.md
+  pull_request:
+    # Can't use an YAML anchor because "Anchors are not currently supported." (GitHub 12/07/2022)
+    paths-ignore:
+      - .gitignore
+      - CLA.md
+      - CODE_OF_CONDUCT.md
+      - CONTRIBUTING.md
+      - cpu-features.md
+      - LICENSE
+      - LICENSE-APACHE
+      - README.md
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup | Update
+        run: sudo apt-get update
+
+      - name: Setup | Install Ninja
+        run: sudo apt-get install ninja-build
+
+      - name: Setup | Install Clang
+        run: |
+          sudo apt-get install clang-11
+          echo "CC=clang-11" >> $GITHUB_ENV
+          echo "CXX=clang++-11" >> $GITHUB_ENV
+
+      - name: Setup | Install LCOV
+        run: sudo apt-get install lcov
+
+      - name: Checkout code
+        uses: actions/checkout@v1
+
+      - name: mach | Build
+        uses: ./.github/actions/mach_build
+        with:
+          bits: 64
+          args: --coverage
+
+      - name: mach | Test
+        uses: ./.github/actions/mach_test
+        with:
+          bits: 64
+          args: --coverage
+
+      - name: Generate reports
+        run: |
+          export PATH=/usr/lib/llvm-11/bin:$PATH
+          chmod +x ./tools/coverage.sh
+          ./tools/coverage.sh
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          path-to-lcov: build/Debug/coverage/full/full.lcov
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,13 @@ endif()
 # Write configuration
 configure_file(config/Config.h.in config.h)
 
+# Coverage
+if(ENABLE_COVERAGE)
+    message(STATUS "Coverage instrumentation enabled")
+    add_compile_options(-fprofile-instr-generate -fcoverage-mapping)
+    add_link_options(-fprofile-instr-generate -fcoverage-mapping)
+endif()
+
 # Sanitizer
 if(ENABLE_ASAN)
     add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
@@ -351,6 +358,12 @@ if(ENABLE_TESTS)
         add_executable(${TEST_NAME}
             ${TEST_FILE}
         )
+
+        # Coverage
+        if(ENABLE_COVERAGE)
+            target_compile_options(${TEST_NAME} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+            target_link_options(${TEST_NAME} PRIVATE -fprofile-instr-generate -fcoverage-mapping)
+        endif()
 
         # Be nice to MSVC and make sure we don't have variable length arrays in
         # tests

--- a/README.md
+++ b/README.md
@@ -150,6 +150,17 @@ packages.
 
 Testing is done with [gtest] and requires a C++11 compiler (or C++20 MSVC).
 
+### Measure Test Coverage
+
+Additional tools are required to measure (and view) test coverage.
+Make sure you have `lcov` and `genhtml`.
+
+For Ubuntu these can be installed via ...
+
+```sh
+$ sudo apt install lcov
+```
+
 ### Dependencies
 
 Tests require the [nlohmann_json] package to read json test files.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,29 @@ Testing is done with [gtest] and requires a C++11 compiler (or C++20 MSVC).
 
 ### Measure Test Coverage
 
-Additional tools are required to measure (and view) test coverage.
+Test coverage in HACL Packages can be measured with ...
+
+```sh
+./mach build --coverage
+./mach test --coverage
+```
+
+Note that only clang is supported as a compiler and you may get an error ...
+
+```
+cc: error: unrecognized command-line option ‘-fprofile-instr-generate’; did you mean ‘-fprofile-generate’?
+```
+
+... when your default compiler is not clang.
+In this case, try to set the `CC` and `CXX` environment variables accordingly ...
+
+```sh
+export CC=clang
+export CXX=clang++
+```
+
+Furthermore, additional tools are required to measure (and view) test coverage.
+
 Make sure you have `lcov` and `genhtml`.
 
 For Ubuntu these can be installed via ...

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Testing is done with [gtest] and requires a C++11 compiler (or C++20 MSVC).
 Test coverage in HACL Packages can be measured with ...
 
 ```sh
-./mach build --coverage
+./mach build --tests --coverage
 ./mach test --coverage
 ./tools/coverage.sh
 ```

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Test coverage in HACL Packages can be measured with ...
 ```sh
 ./mach build --coverage
 ./mach test --coverage
+./tools/coverage.sh
 ```
 
 Note that only clang is supported as a compiler and you may get an error ...
@@ -181,6 +182,12 @@ For Ubuntu these can be installed via ...
 
 ```sh
 $ sudo apt install lcov
+```
+
+When everything went well you should be able to view the coverage reports with, e.g., ...
+
+```sh
+firefox build/Debug/coverage/full/html/index.html
 ```
 
 ### Dependencies

--- a/mach
+++ b/mach
@@ -161,17 +161,8 @@ def build(args):
         cxxflags.append("-m32")
         m32 = True
 
-    if "CC" not in os.environ:
-        print('Please set the "CC" environment variable, e.g., `export CC=...`.')
-        exit(1)
-
-    if "CXX" not in os.environ:
-        print('Please set the "CXX" environment variable, e.g., `export CXX=...`.')
-        exit(1)
-
     # Our default compiler is clang.
-    compiler = os.getenv('CC')
-    compiler_cxx = os.getenv('CXX')
+    compiler = os.getenv('CC', "clang")
 
     windows = False
 
@@ -267,12 +258,7 @@ def build(args):
         # Check that `lcov` and `genhtml` are installed (and callable).
         coverage_dependency_check()
 
-        if "clang" in compiler and "clang++" in compiler_cxx:
-            cmake_args.append("-DENABLE_COVERAGE=ON")
-        else:
-            print(
-                f"Coverage measurement is only supported with clang/clang++ but compilers were {compiler}/{compiler_cxx}.")
-            exit(1)
+        cmake_args.append("-DENABLE_COVERAGE=ON")
 
     if len(cflags) != 0:
         cmake_args.append("-DCMAKE_C_FLAGS=" + ' '.join(cflags))

--- a/mach
+++ b/mach
@@ -156,8 +156,18 @@ def build(args):
         cxxflags.append("-m32")
         m32 = True
 
+    if "CC" not in os.environ:
+        print('Please set the "CC" environment variable, e.g., `export CC=...`.')
+        exit(1)
+
+    if "CXX" not in os.environ:
+        print('Please set the "CXX" environment variable, e.g., `export CXX=...`.')
+        exit(1)
+
     # Our default compiler is clang.
-    compiler = os.getenv('CC', 'clang')
+    compiler = os.getenv('CC')
+    compiler_cxx = os.getenv('CXX')
+
     windows = False
 
     # Select the source folder to use (regular, c89, msvc)

--- a/mach
+++ b/mach
@@ -17,7 +17,9 @@ import os
 import shutil
 from tools.configure import Config
 
-from tools.utils import config_cache, subcommand, argument, json_config, dep_config, cmake_config, cli, subparsers, mprint as print, check_cmd
+from tools.utils import config_cache, subcommand, argument, json_config, \
+    dep_config, cmake_config, cli, subparsers, mprint as print, check_cmd, \
+    coverage_dependency_check
 from tools.test import run_tests
 from tools.macos import ios_sysroot
 from tools.ocaml import build_ocaml, clean_ocaml
@@ -261,6 +263,9 @@ def build(args):
         if windows:
             print("The `--coverage` flag is not supported on Windows.")
             exit(1)
+
+        # Check that `lcov` and `genhtml` are installed (and callable).
+        coverage_dependency_check()
 
         if "clang" in compiler and "clang++" in compiler_cxx:
             cmake_args.append("-DENABLE_COVERAGE=ON")

--- a/mach
+++ b/mach
@@ -72,7 +72,9 @@ def install(args):
                       action='store_true'),
              argument(
                  "-m32", help="Build for 32-bit (even when on 64-bit).", action='store_true'),
-             argument("--no-build", help="Don't actually build (don't run ninja).", action='store_true')])
+             argument(
+                 "--no-build", help="Don't actually build (don't run ninja).", action='store_true'),
+             argument("--coverage", help="Build with coverage instrumentation.", action='store_true')])
 def build(args):
     """Main entry point for building HACL
 
@@ -111,6 +113,7 @@ def build(args):
         - sanitizer
         - edition
         - disable
+        - coverage
     """
     cmake_args = []
     # Verbosity
@@ -252,6 +255,19 @@ def build(args):
 
     # if verbose:
     #     cmake_args.extend(["--debug-output", "--trace"])
+
+    # Check if we want to compile with coverage information.
+    if args.coverage:
+        if windows:
+            print("The `--coverage` flag is not supported on Windows.")
+            exit(1)
+
+        if "clang" in compiler and "clang++" in compiler_cxx:
+            cmake_args.append("-DENABLE_COVERAGE=ON")
+        else:
+            print(
+                f"Coverage measurement is only supported with clang/clang++ but compilers were {compiler}/{compiler_cxx}.")
+            exit(1)
 
     if len(cflags) != 0:
         cmake_args.append("-DCMAKE_C_FLAGS=" + ' '.join(cflags))

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -6,24 +6,20 @@ set -e
 echo "[!] Generating coverage report ... "
 pushd build/Debug
 
+hacl=""
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	hacl=libhacl.so
+else
+	hacl=libhacl.dylib
+fi
+
 mkdir -p coverage/full/html
 llvm-profdata merge -sparse *.profraw -o coverage/full/full.profdata
 llvm-cov export \
 	-format lcov \
 	--instr-profile coverage/full/full.profdata \
-	libhacl.so \
-	-object "blake2b" \
-	-object "blake2s" \
-	-object "chacha20poly1305" \
-	-object "ed25519" \
-	-object "hmac" \
-	-object "p256_ecdh" \
-	-object "p256_ecdsa" \
-	-object "p256k1_ecdsa" \
-	-object "rsapss" \
-	-object "sha2" \
-	-object "sha3" \
-	-object "x25519" \
+	$hacl \
 	../../src/ \
 	> coverage/full/full.lcov
 genhtml coverage/full/full.lcov -o coverage/full/html

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -11,7 +11,8 @@ llvm-profdata merge -sparse *.profraw -o coverage/full/full.profdata
 llvm-cov export \
 	-format lcov \
 	--instr-profile coverage/full/full.profdata \
-	"blake2b" \
+	libhacl.so \
+	-object "blake2b" \
 	-object "blake2s" \
 	-object "chacha20poly1305" \
 	-object "ed25519" \
@@ -23,7 +24,7 @@ llvm-cov export \
 	-object "sha2" \
 	-object "sha3" \
 	-object "x25519" \
-	../../src/*.c \
+	../../src/ \
 	> coverage/full/full.lcov
 genhtml coverage/full/full.lcov -o coverage/full/html
 

--- a/tools/coverage.sh
+++ b/tools/coverage.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+
+set -e
+
+echo "[!] Generating coverage report ... "
+pushd build/Debug
+
+mkdir -p coverage/full/html
+llvm-profdata merge -sparse *.profraw -o coverage/full/full.profdata
+llvm-cov export \
+	-format lcov \
+	--instr-profile coverage/full/full.profdata \
+	"blake2b" \
+	-object "blake2s" \
+	-object "chacha20poly1305" \
+	-object "ed25519" \
+	-object "hmac" \
+	-object "p256_ecdh" \
+	-object "p256_ecdsa" \
+	-object "p256k1_ecdsa" \
+	-object "rsapss" \
+	-object "sha2" \
+	-object "sha3" \
+	-object "x25519" \
+	../../src/*.c \
+	> coverage/full/full.lcov
+genhtml coverage/full/full.lcov -o coverage/full/html
+
+popd
+echo "[!] ... done"

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -107,3 +107,13 @@ def dependency_check():
     # check_cmd("clang")
     print()
     Path(config_check_file()).touch()
+
+
+def coverage_dependency_check():
+    """
+    Check that `lcov`, and `genhtml` are installed (and callable).
+    """
+
+    check_cmd("lcov")
+    check_cmd("genhtml")
+    print()


### PR DESCRIPTION
This PR introduces a workflow to measure test coverage. It adds the `--coverage` flag to the `mach build` and `mach test` subcommands and sets the clang parameters accordingly. When `mach test --coverage` is run, a html report is generated at `build/Debug/coverage/<test>/html/index.html` that can be viewed with a browser. Furthermore, it adds a job "coverage" to integrate with Coveralls.io and show if a PR increases or decreases test coverage.

Note: This PR fails CI on some systems due to the added check in [618f1b4](https://github.com/cryspen/hacl-packages/pull/110/commits/618f1b4c30733fec29216332cba1c7b0a55cd6d6). To make CI pass we need to agree how to detect the compiler in mach first. There are multiple solutions described below.