### PR TITLE
tests: Extend rsapss tests.

### DIFF
--- a/tests/rsapss.cc
+++ b/tests/rsapss.cc
@@ -329,3 +329,50 @@ INSTANTIATE_TEST_SUITE_P(RsaPss4096Sha512Salt32,
                          RsaPssVerifySuite,
                          ::testing::ValuesIn(read_json(const_cast<char*>(
                            "rsa_pss_4096_sha512_mgf1_32_test.json"))));
+
+// -----------------------------------------------------------------------------
+
+TEST(BadSecretKey, RsaPssLoadKey)
+{
+  // (e, d, n)
+  std::vector<std::tuple<bytes, bytes, bytes>> tests{
+    { from_hex(""), from_hex(""), from_hex("") },
+    { from_hex(""), from_hex("AA"), from_hex("") },
+    { from_hex("AA"), from_hex(""), from_hex("") },
+    { from_hex("AA"), from_hex("AA"), from_hex("") },
+    { from_hex("AA"), from_hex("AA"), from_hex("AA") },
+    { from_hex("AA"), from_hex("AAAA"), from_hex("AA") },
+    { from_hex("AAAA"), from_hex("AA"), from_hex("AA") },
+    { from_hex("AAAA"), from_hex("AAAA"), from_hex("AA") },
+  };
+
+  for (auto test : tests) {
+    bytes e, d, n;
+    std::tie(e, d, n) = test;
+
+    uint64_t* skey = Hacl_RSAPSS_new_rsapss_load_skey(
+      n.size() * 8, e.size() * 8, d.size() * 8, n.data(), e.data(), d.data());
+
+      ASSERT_TRUE(skey == NULL);
+  }
+}
+
+TEST(BadPublicKey, RsaPssLoadKey)
+{
+  // (e, n)
+  std::vector<std::tuple<bytes, bytes>> tests{
+    { from_hex(""), from_hex("") },
+    { from_hex(""), from_hex("FF") },
+    { from_hex("AA"), from_hex("") },
+  };
+
+  for (auto test : tests) {
+    bytes e, n;
+    std::tie(e, n) = test;
+
+    uint64_t* pkey = Hacl_RSAPSS_new_rsapss_load_pkey(
+      n.size() * 8, e.size() * 8, n.data(), e.data());
+
+    ASSERT_TRUE(pkey == NULL);
+  }
+}


### PR DESCRIPTION
This PR adds tests to see if `Hacl_RSAPSS_new_rsapss_load_skey` and `Hacl_RSAPSS_new_rsapss_load_pkey` accept bad keys and that signing and verification error out on a bad hash function parameter.

This PR should also serve as a test if the integration with Coveralls.io works as expected.