### PR TITLE
tests: Extend md5 tests.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -375,6 +375,9 @@
         "hmac": [
             "hmac.cc"
         ],
+        "md5": [
+            "md5.cc"
+        ],
         "sha2": [
             "sha2.cc"
         ],

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,6 +35,10 @@ The test vectors are from [Project Wycheproof].
 
 *Note:* SHA-1 is not supported in Hacl and thus not tested.
 
+## md5
+
+The test vectors are from [RFC1321].
+
 ## sha2
 
 The test vectors are from [Cryptographic Algorithm Validation Program].
@@ -51,3 +55,4 @@ The test vectors are from [Project Wycheproof].
 [emilbayes/blake2b]: https://github.com/emilbayes/blake2b/blob/master/test-vectors.json
 [NIST's Cryptographic Algorithm Validation Program]: https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/Secure-Hashing
 [Project Wycheproof]: https://github.com/google/wycheproof/tree/2196000605e45d91097147c9c71f26b72af58003
+[RFC1321]: https://datatracker.ietf.org/doc/html/rfc1321

--- a/tests/md5.cc
+++ b/tests/md5.cc
@@ -1,0 +1,69 @@
+/*
+ *    Copyright 2022 Cryspen Sarl
+ *
+ *    Licensed under the Apache License, Version 2.0 or MIT.
+ *    - http://www.apache.org/licenses/LICENSE-2.0
+ *    - http://opensource.org/licenses/MIT
+ */
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "Hacl_Hash_Base.h"
+#include "Hacl_Hash_MD5.h"
+#include "Hacl_Spec.h"
+#include "util.h"
+
+using json = nlohmann::json;
+
+typedef struct
+{
+  bytes message;
+  bytes hash;
+} TestCase;
+
+class Md5Suite : public ::testing::TestWithParam<TestCase>
+{};
+
+TEST_P(Md5Suite, TestCase)
+{
+  auto test = GetParam();
+
+  bytes got_hash = std::vector<uint8_t>(16);
+  Hacl_Hash_MD5_legacy_hash(
+    test.message.data(), test.message.size(), got_hash.data());
+
+  EXPECT_EQ(got_hash, test.hash);
+}
+
+std::vector<TestCase>
+read_json(char* path)
+{
+  json tests_raw;
+  std::ifstream file(path);
+  file >> tests_raw;
+
+  std::vector<TestCase> tests;
+
+  for (auto& test_raw : tests_raw.items()) {
+    auto test = test_raw.value();
+
+    std::string message_str = test["message"];
+    std::vector<uint8_t> message(message_str.begin(), message_str.end());
+    bytes hash = from_hex(test["hash"]);
+
+    tests.push_back(TestCase{
+      .message = message,
+      .hash = hash,
+    });
+  }
+
+  return tests;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  Rfc1231,
+  Md5Suite,
+  ::testing::ValuesIn(read_json(const_cast<char*>("rfc1321.json"))));

--- a/tests/md5.cc
+++ b/tests/md5.cc
@@ -67,3 +67,8 @@ INSTANTIATE_TEST_SUITE_P(
   Rfc1231,
   Md5Suite,
   ::testing::ValuesIn(read_json(const_cast<char*>("rfc1321.json"))));
+
+INSTANTIATE_TEST_SUITE_P(
+  Cryspen,
+  Md5Suite,
+  ::testing::ValuesIn(read_json(const_cast<char*>("cryspen_md5.json"))));

--- a/tests/md5/cryspen_md5.json
+++ b/tests/md5/cryspen_md5.json
@@ -1,0 +1,10 @@
+[
+  {
+    "message": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "hash": "c1bb4f81d892b2d57947682aeb252456"
+  },
+  {
+    "message": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxA",
+    "hash": "37863e60f85afcfaa7fc3eab112d3c04"
+  }
+]

--- a/tests/md5/cryspen_md5.json
+++ b/tests/md5/cryspen_md5.json
@@ -1,5 +1,9 @@
 [
   {
+    "message": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "hash": "7dc2ca208106a2f703567bdff99d8981"
+  },
+  {
     "message": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
     "hash": "c1bb4f81d892b2d57947682aeb252456"
   },

--- a/tests/md5/rfc1321.json
+++ b/tests/md5/rfc1321.json
@@ -1,0 +1,30 @@
+[
+  {
+    "message": "",
+    "hash": "d41d8cd98f00b204e9800998ecf8427e"
+  },
+  {
+    "message": "a",
+    "hash": "0cc175b9c0f1b6a831c399e269772661"
+  },
+  {
+    "message": "abc",
+    "hash": "900150983cd24fb0d6963f7d28e17f72"
+  },
+  {
+    "message": "message digest",
+    "hash": "f96b697d7cb7938d525a2f31aaf161d0"
+  },
+  {
+    "message": "abcdefghijklmnopqrstuvwxyz",
+    "hash": "c3fcd3d76192e4007dfb496cca67e13b"
+  },
+  {
+    "message": "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+    "hash": "d174ab98d277d9f5a5611c2c9f419d9f"
+  },
+  {
+    "message": "12345678901234567890123456789012345678901234567890123456789012345678901234567890",
+    "hash": "57edf4a22be3c955ac49da2e2107b67a"
+  }
+]


### PR DESCRIPTION
This PR adds tests for the `Hacl_Hash_MD5_legacy_hash` function. The function `Hacl_Hash_Core_MD5_legacy_init` is not covered.