### PR TITLE
Minor Rust update

### DIFF
--- a/rust/hacl-rust-sys/build.rs
+++ b/rust/hacl-rust-sys/build.rs
@@ -116,6 +116,20 @@ fn main() {
     // This is the default behaviour. It can be disabled when working on this
     // to pick up the local version. This is what the global mach script does.
     let hacl_path = if !mach_build {
+        // Check if we have to copy the C files first.
+        if !home_dir.join("..").join(".c").exists() {
+            println!(" >>> Copying HACL C file");
+            // ./mach rust
+            let mut mach_cmd = Command::new("./mach");
+            let cmake_status = mach_cmd
+                .current_dir(home_dir.join("..").join(".."))
+                .args(&["rust"])
+                .status()
+                .expect("Failed to run ./mach rust.");
+            if !cmake_status.success() {
+                panic!("Failed to run ./mac rust.")
+            }
+        }
         let c_path = home_dir.join("..").join(".c");
         build_hacl_c(&c_path);
         c_path.join("build").join("installed")

--- a/rust/src/digest.rs
+++ b/rust/src/digest.rs
@@ -238,14 +238,6 @@ impl From<Algorithm> for Spec_Hash_Definitions_hash_alg {
     }
 }
 
-#[deprecated(
-    since = "0.0.10",
-    note = "Please use digest_size instead. This alias will be removed with the first stable 0.1 release."
-)]
-pub fn get_digest_size(mode: Algorithm) -> usize {
-    digest_size(mode)
-}
-
 /// Returns the output size of a digest.
 pub const fn digest_size(mode: Algorithm) -> usize {
     match mode {
@@ -260,6 +252,12 @@ pub const fn digest_size(mode: Algorithm) -> usize {
         Algorithm::Sha3_256 => 32,
         Algorithm::Sha3_384 => 48,
         Algorithm::Sha3_512 => 64,
+    }
+}
+
+impl Algorithm {
+    pub fn size(self) -> usize {
+        digest_size(self)
     }
 }
 

--- a/rust/src/hmac.rs
+++ b/rust/src/hmac.rs
@@ -33,14 +33,6 @@ pub enum Algorithm {
     Sha512 = Spec_Hash_Definitions_SHA2_512 as isize,
 }
 
-#[deprecated(
-    since = "0.0.10",
-    note = "Please use tag_size instead. This alias will be removed with the first stable 0.1 release."
-)]
-pub fn get_tag_size(mode: Algorithm) -> usize {
-    tag_size(mode)
-}
-
 /// Get the tag size for a given mode.
 pub const fn tag_size(mode: Algorithm) -> usize {
     match mode {

--- a/rust/src/rsa_pss.rs
+++ b/rust/src/rsa_pss.rs
@@ -39,6 +39,20 @@ pub enum KeySize {
     N8192 = 1024,
 }
 
+impl TryFrom<usize> for KeySize {
+    type Error = Error;
+    fn try_from(s: usize) -> Result<KeySize, Self::Error> {
+        match s {
+            256 => Ok(Self::N2048),
+            384 => Ok(Self::N3072),
+            512 => Ok(Self::N4096),
+            768 => Ok(Self::N6144),
+            1024 => Ok(Self::N8192),
+            _ => Err(Error::InvalidKeySize),
+        }
+    }
+}
+
 /// An RSA-PSS public key
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PublicKey {


### PR DESCRIPTION
- remove some deprecated functions
- make the crate usable as git dependency
- implement `try_from` for `KeySize` in RsaPss