### PR TITLE
windows clang-cl assembly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ if(TOOLCHAIN_CAN_COMPILE_VALE)
     # Select the files for the target OS/Compiler
     if(WIN32 AND NOT MSVC)
         # On Windows with clang-cl (our default) we take the Linux assembly
-        set(VALE_OBJECTS ${VALE_SOURCES_linux})
+        set(VALE_OBJECTS ${VALE_SOURCES_mingw})
     else()
         set(VALE_OBJECTS ${VALE_SOURCES_${HACL_TARGET_OS}})
     endif()
@@ -261,14 +261,17 @@ if(TOOLCHAIN_CAN_COMPILE_VALE)
     # Add SOURCES_vale to SOURCES_std as we don't need any
     # special compiler flags for it.
     list(APPEND SOURCES_std ${SOURCES_vale})
+    message(STATUS "Detected vale support")
     set(HACL_CAN_COMPILE_VALE 1)
 endif()
 
 if(TOOLCHAIN_CAN_COMPILE_INLINE_ASM)
+    message(STATUS "Detected inline assembly support")
     set(HACL_CAN_COMPILE_INLINE_ASM 1)
 endif()
 
 if(TOOLCHAIN_CAN_COMPILE_INTRINSICS)
+    message(STATUS "Detected intrinsics support")
     set(HACL_CAN_COMPILE_INTRINSICS 1)
 endif()
 

--- a/config/toolchain.cmake
+++ b/config/toolchain.cmake
@@ -96,11 +96,17 @@ if(NOT DEFINED TOOLCHAIN_CAN_COMPILE_INLINE_ASM)
     set(TOOLCHAIN_CAN_COMPILE_INLINE_ASM OFF)
     # Only available on x64
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64|AMD64")
-        execute_process(COMMAND
-            ${PROJECT_SOURCE_DIR}/config/osx_c.sh ${CMAKE_C_COMPILER}
-            RESULT_VARIABLE BAD_CC
-        )
-        if(${BAD_CC} EQUAL 1)
+        if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            execute_process(COMMAND
+                ${PROJECT_SOURCE_DIR}/config/osx_c.sh ${CMAKE_C_COMPILER}
+                RESULT_VARIABLE BAD_CC
+            )
+            # Only enable inline ASM when we don't have a bad compiler and are not
+            # on Windows.
+            if(${BAD_CC} EQUAL 0)
+                set(TOOLCHAIN_CAN_COMPILE_INLINE_ASM TRUE)
+            endif()
+        elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
             set(TOOLCHAIN_CAN_COMPILE_INLINE_ASM TRUE)
         endif()
     endif()

--- a/tools/ocaml.py
+++ b/tools/ocaml.py
@@ -65,4 +65,5 @@ def clean_ocaml():
     '''Clean the OCaml build.
     '''
     make_cmd = ['make', '-C', 'ocaml', 'clean']
-    subprocess.run(make_cmd, check=True)
+    # This is noisy.
+    subprocess.run(make_cmd, check=True, stdout=subprocess.DEVNULL)


### PR DESCRIPTION
Looks like there are some oddities in the linux assembly that doesn't work here, i.e. ensuring the input stack is usable. The mingw version appears to have the necessary pieces.