### PR TITLE
opam fixes for 0.5.0

### DIFF
--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -89,7 +89,7 @@ jobs:
         run: sudo apt-get install ninja-build opam libgmp-dev
       - name: Setup macOS
         if: matrix.os == 'macos-latest'
-        run: brew install ninja opam libgmp
+        run: brew install ninja opam gmp
       - name: OCaml Setup
         if: steps.cache-ocaml-setup.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -67,6 +67,12 @@ jobs:
 
   packaging:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
@@ -78,8 +84,12 @@ jobs:
           path: ~/.opam
           key: ${{ runner.os }}-ocaml-setup
 
-      - name: System Setup
+      - name: Setup Ubuntu
+        if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install ninja-build opam libgmp-dev
+      - name: Setup macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install ninja opam libgmp
       - name: OCaml Setup
         if: steps.cache-ocaml-setup.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -66,13 +66,13 @@ jobs:
   #         ./mach test -l ocaml -v
 
   packaging:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         os:
           - macos-latest
           - ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,6 @@ endif()
 project(hacl
     VERSION 0.1.0
     DESCRIPTION "The High Assurance Crypto Library"
-    HOMEPAGE_URL "https://www.cryspen.com/hacl"
     LANGUAGES C CXX
 )
 
@@ -355,7 +354,9 @@ endif()
 set(CMAKE_INSTALL_LIBDIR lib)
 include(GNUInstallDirs)
 set(CMAKE_INSTALL_MESSAGE LAZY)
-install(TARGETS hacl_static hacl ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS hacl_static hacl
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # # Copy hacl headers
 install(FILES ${PUBLIC_INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hacl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ endif()
 set(CMAKE_INSTALL_LIBDIR lib)
 include(GNUInstallDirs)
 set(CMAKE_INSTALL_MESSAGE LAZY)
-install(TARGETS hacl_static hacl)
+install(TARGETS hacl_static hacl ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 # # Copy hacl headers
 install(FILES ${PUBLIC_INCLUDES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hacl)

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -44,8 +44,11 @@ C_DYN_LIB?=lib$(DYNAMIC_C_LIB_NAME).$(SO)
 # Compiling the C library. This needs to be executed before and independently
 # of build-bindings because it will also write Makefile.config, which is needed
 # by build-bindings.
+#
+# Note that cmake 3.10 does not support -B to output build files to a different
+# directory. Hence the other way of calling it here.
 build-c:
-	cmake -B build -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release
+	cd build && cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ../
 	make -C build
 	cp build/$(C_LIB) .
 	cp build/$(C_DYN_LIB) .

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -104,11 +104,15 @@ lib_gen/Lib_RandomBuffer_System_gen.exe: lib/Lib_RandomBuffer_System_bindings.cm
 
 %.exe:
 
+uname_m=$(shell uname -m)
+OCAML_CFLAGS.s390x=-mvx
+OCAML_CFLAGS+=$(OCAML_CFLAGS.$(uname_m))
+
 lib_gen/%_gen.exe:
 	$(OCAMLOPT) $(filter-out %.a,$^) $(C_LIB) -o $@
 
 %.cmx: %.ml
-	$(OCAMLOPT) -c $^ -o $@
+	$(OCAMLOPT) $(OCAML_CFLAGS) -c $^ -o $@
 
 %.cmo: %.ml
 	$(OCAMLC) -c $^ -o $@

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -147,8 +147,8 @@ clean:
 # Install hacl-star-raw locally.
 install: dllocamlevercrypt.$(OCAML_SO)
 # We need to remove all comments from config.h because ccpo can't handle them
-	sed 's/\(\/\/.*\)\|\(\/\*.*\*\/\)//g' build/config.h > build/config-new.h
-	mv build/config-new.h build/config.h
+	sed 's/\(\/\/.*\)//g' build/config.h > build/config-new.h
+	sed 's/\(\/\*.*\*\/\)//g' build/config-new.h > build/config.h
 	ocamlfind remove hacl-star-raw || true
 	ocamlfind install hacl-star-raw META
 	ocamlfind install -add hacl-star-raw $(CTYPES_ML)

--- a/ocaml/Makefile
+++ b/ocaml/Makefile
@@ -105,14 +105,14 @@ lib_gen/Lib_RandomBuffer_System_gen.exe: lib/Lib_RandomBuffer_System_bindings.cm
 %.exe:
 
 uname_m=$(shell uname -m)
-OCAML_CFLAGS.s390x=-mvx
-OCAML_CFLAGS+=$(OCAML_CFLAGS.$(uname_m))
+OCAML_CFLAGS.s390x=-m64 -mzarch -mvx -mzvector -march=native -O3
+CFLAGS+=$(OCAML_CFLAGS.$(uname_m))
 
 lib_gen/%_gen.exe:
 	$(OCAMLOPT) $(filter-out %.a,$^) $(C_LIB) -o $@
 
 %.cmx: %.ml
-	$(OCAMLOPT) $(OCAML_CFLAGS) -c $^ -o $@
+	$(OCAMLOPT) -c $^ -o $@
 
 %.cmo: %.ml
 	$(OCAMLC) -c $^ -o $@

--- a/ocaml/hacl-star-raw.opam
+++ b/ocaml/hacl-star-raw.opam
@@ -15,6 +15,7 @@ homepage: "https://hacl-star.github.io/"
 bug-reports: "https://github.com/project-everest/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }
+  "dune" {>= "1.2"}
   "ocamlfind" {build}
   "ctypes" { >= "0.18.0" }
   "conf-which" {build}

--- a/ocaml/hacl-star-raw.opam
+++ b/ocaml/hacl-star-raw.opam
@@ -21,7 +21,7 @@ depends: [
   "conf-cmake" {build}
 ]
 available: [
-  arch != "ppc64" & arch != "ppc32" &
+  arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
   (os = "freebsd" | os-family != "bsd")
 ]
 x-ci-accept-failures: [


### PR DESCRIPTION
- use simple sed regex for bsd sed
- disable arm32 for now for the hacl-star-raw package

### ToDo
- [x] fix on cmake 3.10 and 3.13
  - https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/36ce9625967f4500f987edb78364b9ae57340696/variant/distributions,debian-10,hacl-star-raw.0.5.0
  - https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/36ce9625967f4500f987edb78364b9ae57340696/variant/distributions,ubuntu-18.04,hacl-star-raw.0.5.0
- [x] fix s390x
  - https://opam.ci.ocaml.org/github/ocaml/opam-repository/commit/36ce9625967f4500f987edb78364b9ae57340696/variant/extras,s390x,hacl-star-raw.0.5.0