### PR TITLE
docs: HMAC

### DIFF
--- a/docs/reference/evercrypt/index.md
+++ b/docs/reference/evercrypt/index.md
@@ -5,5 +5,6 @@
 :caption: "EverCrypt:"
 
 aead/index
+mac/index
 ```
 

--- a/docs/reference/evercrypt/mac/index.md
+++ b/docs/reference/evercrypt/mac/index.md
@@ -1,0 +1,124 @@
+# MAC
+
+A Message Authentication Code (MAC) provides data integrity and authenticity of a message.
+
+## HMAC
+
+An HMAC is a specific construction of a MAC that involves a cryptographic hash function (see [RFC 2104]).
+Thus, an HMAC comes in multiple instantiations.
+HACL Packages supports the following ones:
+
+* HMAC-BLAKE2b,
+* HMAC-BLAKE2s,
+* HMAC-SHA-2-256,
+* HMAC-SHA-2-384,
+* HMAC-SHA-2-512, and
+* HMAC-SHA-1.
+
+Keys must be chosen using a cryptographically strong pseudo-random generator and periodically refreshed.
+
+# HMAC
+
+## API Reference
+
+```C
+#include "Hacl_Spec.h"
+```
+
+```{doxygentypedef} Spec_Hash_Definitions_hash_alg
+```
+
+```{doxygendefine} Spec_Hash_Definitions_SHA2_224
+```
+
+```{doxygendefine} Spec_Hash_Definitions_SHA2_256
+```
+
+```{doxygendefine} Spec_Hash_Definitions_SHA2_384
+```
+
+```{doxygendefine} Spec_Hash_Definitions_SHA2_512
+```
+
+```{doxygendefine} Spec_Hash_Definitions_SHA1
+```
+
+```{doxygendefine} Spec_Hash_Definitions_MD5
+```
+
+```{doxygendefine} Spec_Hash_Definitions_Blake2S
+```
+
+```{doxygendefine} Spec_Hash_Definitions_Blake2B
+```
+
+The available hash functions.
+
+--------------------------------------------------------------------------------
+
+```{doxygenfunction} EverCrypt_HMAC_is_supported_alg
+```
+
+Check that a hash function is supported to be used in the HMAC construction.
+
+```{doxygenfunction} EverCrypt_HMAC_compute
+```
+
+Write the MAC of a message (`data`) by using the hash algorithm `a` with a key (`key`) into `dst`.
+ 
+The recommended size for the `key` depends on the used hash algorithm (see below).
+However, the key can be any length and will be hashed if it is longer and padded if it is shorter.
+The length of `dst` depends on the output length of the used hash algorithm (see below).
+
+--------------------------------------------------------------------------------
+
+# BLAKE2b
+
+```{doxygenfunction} EverCrypt_HMAC_compute_blake2b
+```
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 128 bytes.
+`dst` must point to 64 bytes of memory.
+
+--------------------------------------------------------------------------------
+
+# BLAKE2s
+
+
+```{doxygenfunction} EverCrypt_HMAC_compute_blake2s
+```
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 64 bytes.
+`dst` must point to 32 bytes of memory.
+
+--------------------------------------------------------------------------------
+
+# SHA-2
+
+```{doxygenfunction} EverCrypt_HMAC_compute_sha2_256
+```
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 64 bytes.
+`dst` must point to 32 bytes of memory.
+
+```{doxygenfunction} EverCrypt_HMAC_compute_sha2_384
+```
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 128 bytes.
+`dst` must point to 48 bytes of memory.
+
+```{doxygenfunction} EverCrypt_HMAC_compute_sha2_512
+```
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 128 bytes.
+`dst` must point to 64 bytes of memory.
+
+--------------------------------------------------------------------------------
+
+# SHA-1
+
+```{doxygenfunction} EverCrypt_HMAC_compute_sha1
+```
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 64 bytes.
+`dst` must point to 20 bytes of memory.

--- a/docs/reference/hacl/mac/index.md
+++ b/docs/reference/hacl/mac/index.md
@@ -1,61 +1,123 @@
 # MAC
 
+A Message Authentication Code (MAC) provides data integrity and authenticity of a message.
+
 ## HMAC
+
+An HMAC is a specific construction of a MAC that involves a cryptographic hash function (see [RFC 2104]).
+Thus, an HMAC comes in multiple instantiations.
+HACL Packages supports the following ones:
+
+* HMAC-BLAKE2b,
+* HMAC-BLAKE2s,
+* HMAC-SHA-2-256,
+* HMAC-SHA-2-384,
+* HMAC-SHA-2-512, and
+* HMAC-SHA-1.
+
+Keys must be chosen using a cryptographically strong pseudo-random generator and periodically refreshed.
+Note that the key can be of any length up to the specific block length of the used hash algorithm.
+This is also mentioned in the API reference below.
+
+## Implementations
+
+`````{tabs}
+````{group-tab} 32
+This implementation works on any CPU.
+````
+
+````{group-tab} 128
+```{note}
+Support for VEC128 is needed. Please see the <a href="https://tech.cryspen.com/hacl-packages/algorithms.html">HACL Packages book</a>.
+```
+````
+
+````{group-tab} 256
+```{note}
+Support for VEC256 is needed. Please see the <a href="https://tech.cryspen.com/hacl-packages/algorithms.html">HACL Packages book</a>.
+```
+````
+`````
 
 ### API Reference
 
 #### BLAKE2b
 
-
 `````{tabs}
-
-````{tab} 32
-
+````{group-tab} 32
 ```{doxygenfunction} Hacl_HMAC_compute_blake2b_32
 ```
-
 ````
 
-````{tab} 256
-
+````{group-tab} 256
 ```{doxygenfunction} Hacl_HMAC_Blake2b_256_compute_blake2b_256
 ```
-
 ````
 `````
+
+Write the HMAC-BLAKE2b MAC of a message (`data`) by using a key (`key`) into `dst`.
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 128 bytes.
+`dst` must point to 64 bytes of memory.
+
+--------------------------------------------------------------------------------
 
 #### BLAKE2s
 
 `````{tabs}
-
-````{tab} 32
-
+````{group-tab} 32
 ```{doxygenfunction} Hacl_HMAC_compute_blake2s_32
 ```
-
 ````
-
-````{tab} 128
-
+````{group-tab} 128
 ```{doxygenfunction} Hacl_HMAC_Blake2s_128_compute_blake2s_128
 ```
-
 ````
 `````
+
+Write the HMAC-BLAKE2s MAC of a message (`data`) by using a key (`key`) into `dst`.
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 64 bytes.
+`dst` must point to 32 bytes of memory.
+
+--------------------------------------------------------------------------------
 
 #### SHA-2
 
 ```{doxygenfunction} Hacl_HMAC_compute_sha2_256
 ```
 
+Write the HMAC-SHA-2-256 MAC of a message (`data`) by using a key (`key`) into `dst`.
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 64 bytes.
+`dst` must point to 32 bytes of memory.
+
 ```{doxygenfunction} Hacl_HMAC_compute_sha2_384
 ```
 
+Write the HMAC-SHA-2-384 MAC of a message (`data`) by using a key (`key`) into `dst`.
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 128 bytes.
+`dst` must point to 48 bytes of memory.
+
 ```{doxygenfunction} Hacl_HMAC_compute_sha2_512
 ```
+
+Write the HMAC-SHA-2-512 MAC of a message (`data`) by using a key (`key`) into `dst`.
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 128 bytes.
+`dst` must point to 64 bytes of memory.
+
+--------------------------------------------------------------------------------
 
 #### SHA-1
 
 ```{doxygenfunction} Hacl_HMAC_legacy_compute_sha1
 ```
 
+Write the HMAC-SHA-1 MAC of a message (`data`) by using a key (`key`) into `dst`.
+
+The key can be any length and will be hashed if it is longer and padded if it is shorter than 64 byte.
+`dst` must point to 20 bytes of memory.
+
+[rfc 2104]: https://www.ietf.org/rfc/rfc2104.txt


### PR DESCRIPTION
This PR adds documentation for HMAC (HACL + EverCrypt).

I am not sure about the recommended key sizes, though. Do we want to make a recommendation at all? Or do we want to explain key sizes for HMAC in more detail in the book?