### PR TITLE
lock breathe version

### DIFF
--- a/docs/reference/requirements.txt
+++ b/docs/reference/requirements.txt
@@ -5,4 +5,4 @@ pydata-sphinx-theme
 sphinx-book-theme
 
 sphinx-tabs
-breathe
+breathe==4.33.1


### PR DESCRIPTION
It seems that the latest release for `breathe` is broken.

Before locking the version, this is the error I got when running `pip install`:

```
error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in breathe setup command: use_2to3 is invalid.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```