### PR TITLE
docs: Add (tested) BLAKE2b example to API reference.

### DIFF
--- a/docs/reference/hacl/hash/blake2/blake2b.md
+++ b/docs/reference/hacl/hash/blake2/blake2b.md
@@ -3,10 +3,34 @@
 BLAKE2b is optimized for 64-bit platforms and produces digests of any size between 1 and 64 bytes.
 It also has a build-in keying mechanism so that it can be used to replace HMAC-based constructions.
 
+## Example
+
+The following example shows how to use the one-shot API with the base implementation (32) of BLAKE2b.
+
+```{literalinclude} ../../../../../tests/blake2b.cc
+:language: C
+:dedent:
+:start-after: "// API EXAMPLE INCLUDE START"
+:end-before: "// API EXAMPLE INCLUDE END"
+```
+
+```{literalinclude} ../../../../../tests/blake2b.cc
+:language: C
+:dedent:
+:start-after: "// API EXAMPLE HEX START"
+:end-before: "// API EXAMPLE HEX END"
+```
+
+```{literalinclude} ../../../../../tests/blake2b.cc
+:language: C
+:dedent:
+:start-after: "// API EXAMPLE CODE START"
+:end-before: "// API EXAMPLE CODE END"
+```
+
 ## API Reference
 
 ### One-Shot
-
 
 `````{tabs}
 ````{group-tab} 32

--- a/tests/blake2b.cc
+++ b/tests/blake2b.cc
@@ -10,7 +10,9 @@
 #include <nlohmann/json.hpp>
 
 #include "EverCrypt_Hash.h"
+// API EXAMPLE INCLUDE START
 #include "Hacl_Hash_Blake2.h"
+// API EXAMPLE INCLUDE END
 #include "Hacl_Streaming_Blake2.h"
 #include "config.h"
 #include "evercrypt.h"
@@ -33,6 +35,46 @@
 
 using json = nlohmann::json;
 using namespace std;
+
+// -----------------------------------------------------------------------------
+
+// API EXAMPLE HEX START
+void
+print_hex_ln(size_t bytes_len, uint8_t* bytes)
+{
+  for (int i = 0; i < bytes_len; ++i) {
+    printf("%02x", bytes[i]);
+  }
+
+  printf("\n");
+}
+// API EXAMPLE HEX END
+
+TEST(ApiTestSuite, ApiTest)
+{
+  // API EXAMPLE CODE START
+  // Reserve memory for a 64 byte digest, i.e.,
+  // for a BLAKE2B run with full 512-bit output.
+  uint32_t output_len = 64;
+  uint8_t output[64];
+
+  // The message we want to hash.
+  const char* message = "Hello, HACL Packages!";
+  uint32_t message_len = strlen(message);
+
+  // BLAKE2B can be used as an HMAC, i.e., with a key.
+  // We don't want to use a key here and thus provide a zero-sized key.
+  uint32_t key_len = 0;
+  uint8_t* key = 0;
+
+  Hacl_Blake2b_32_blake2b(
+    output_len, output, message_len, (uint8_t*)message, key_len, key);
+
+  print_hex_ln(output_len, output);
+  // API EXAMPLE CODE END
+}
+
+// -----------------------------------------------------------------------------
 
 class TestCase
 {


### PR DESCRIPTION
Work towards #193. BLAKE2b had higher priority IMO because we should have that in the documentation before the blog post.