### PR TITLE
ci: Eagerly cancel superseded workflows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,10 @@ on:
       - README.md
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -13,6 +13,10 @@ on:
       - README.md
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux:
     runs-on: ubuntu-22.04

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,6 +26,10 @@ on:
       - README.md
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -26,6 +26,10 @@ on:
       - README.md
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # mach:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,6 +26,10 @@ on:
       - README.md
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   mach:
     strategy:

--- a/.github/workflows/sanitizer_builds.yml
+++ b/.github/workflows/sanitizer_builds.yml
@@ -16,6 +16,10 @@ on:
       - README.md
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This closes #253.

Explanation:

GitHub Actions allows to define a concurrency group -- as a string -- for a workflow. Two workflow runs in the same group will be sequenced by default. By using `cancel-in-progress: true` we cancel the superseded ones instead. This is useful because, often, we commit small changes such as reviewer suggesstions in the review process. These additional commits spawn new workflow runs that run *in addition* to the (now superseded) pending workflow runs.

I propose to cancel these as fast as possible to make the CI more responsive and to not waste computing power.

By putting the workflow into the concurrency group with name ...

```yaml
  group: ${{ github.workflow }}-${{ github.ref }}
```

... we make sure that a workflow "A" does not cancel a workflow "B". Thus, cancelations of a workflow should only be done by running that same workflow again.

Exclaimer:

I've done some sanity tests in my repos using this and it seems to work as expected. But I can imagine we will want to tweak this over time.