### PR TITLE
CI: Don't set OPAMYES

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Setup | OCaml
         run: |
-          OPAMYES=true opam init --auto-setup --disable-sandboxing --yes --bare
+          opam init --auto-setup --disable-sandboxing --yes --bare
           opam switch create 4.12.0 --yes
           eval $(opam env)
           opam install --yes ocamlfind odoc ctypes zarith cppo dune
@@ -79,11 +79,11 @@ jobs:
 
       - name: Build | OCaml API Reference
         run: |
-          eval $(opam env)
           mkdir -p build/ocaml/main
           ./opam.sh
           cd opam
-          opam install .  --yes
+          eval $(opam env)
+          opam install . --yes
           dune build @doc
           cp -r _build/default/_doc/_html/* ../build/ocaml/main/
 

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -49,7 +49,7 @@ jobs:
   #     - name: OCaml Setup
   #       if: steps.cache-ocaml-setup.outputs.cache-hit != 'true'
   #       run: |
-  #         OPAMYES=true opam init --auto-setup --disable-sandboxing --yes --bare
+  #         opam init --auto-setup --disable-sandboxing --yes --bare
   #         opam switch create 4.12.0 --yes
   #         eval $(opam env)
   #         opam install --yes ocamlfind ctypes zarith cppo
@@ -97,7 +97,7 @@ jobs:
       - name: OCaml Setup
         if: steps.cache-ocaml-setup.outputs.cache-hit != 'true'
         run: |
-          OPAMYES=true opam init --auto-setup --disable-sandboxing --yes --bare
+          opam init --auto-setup --disable-sandboxing --yes --bare
           opam switch create 4.12.0 --yes
           eval $(opam env)
           opam install --yes ocamlfind ctypes zarith cppo


### PR DESCRIPTION
Try not setting `OPAMYES`, which might prompt opam to install system packages which are already present.