### PR TITLE
OCaml: use --only-packages=hacl-star when building docs

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -84,7 +84,7 @@ jobs:
           cd opam
           eval $(opam env)
           opam install . --yes --assume-depexts
-          dune build @doc
+          dune build @doc --only-packages=hacl-star
           cp -r _build/default/_doc/_html/* ../build/ocaml/main/
 
       - name: Upload artifact

--- a/ocaml/hacl-star/hacl-star.opam
+++ b/ocaml/hacl-star/hacl-star.opam
@@ -4,13 +4,13 @@ version: "0.5.0"
 synopsis: "OCaml API for EverCrypt/HACL*"
 description: """
 Documentation for this library can be found
-[here](https://hacl-star.github.io/ocaml_doc/hacl-star/index.html).
+[here](https://tech.cryspen.com/hacl-packages/ocaml/main/index.html).
 """
 maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
 homepage: "https://hacl-star.github.io/"
-doc: "https://hacl-star.github.io/ocaml_doc"
+doc: "https://tech.cryspen.com/hacl-packages/ocaml/main/index.html"
 bug-reports: "https://github.com/project-everest/hacl-star/issues"
 depends: [
   "ocaml" { >= "4.08.0" }

--- a/tools/doc.py
+++ b/tools/doc.py
@@ -50,7 +50,7 @@ def doc(args):
         os.makedirs("build/docs/ocaml/main", exist_ok=True)
         subprocess.call(["sh", "opam.sh"])
         os.chdir("opam")
-        subprocess.call(["dune", "build", "@doc"])
+        subprocess.call(["dune", "build", "@doc", "--only-packages=hacl-star"])
         os.chdir(backup)
         shutil.copytree(
             "opam/_build/default/_doc/_html",


### PR DESCRIPTION
This avoids building and linking to the (non-existent) docs for `hacl-star-raw` on the [docs page](https://tech.cryspen.com/hacl-packages/ocaml/main/index.html)