### PR TITLE
use macos-11 on CI for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
           name: linux_${{ matrix.compiler }}_v${{ matrix.version }}_${{ matrix.bits }}_${{ matrix.edition }}
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       matrix:
         compiler: [gcc, clang]

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -71,7 +71,7 @@ jobs:
           name: linux_${{ matrix.compiler }}_${{ matrix.bits }}_${{ matrix.edition }}
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-11
     strategy:
       matrix:
         compiler: [gcc, clang]

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-11
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
 
@@ -92,7 +92,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get install ninja-build opam libgmp-dev
       - name: Setup macOS
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-11'
         run: brew install ninja opam gmp
       - name: OCaml Setup
         if: steps.cache-ocaml-setup.outputs.cache-hit != 'true'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-11
           - ubuntu-latest
           - windows-latest
 
@@ -54,7 +54,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo
 
-      - if: matrix.os == 'macos-latest'
+      - if: matrix.os == 'macos-11'
         run: brew install ninja
 
       - if: matrix.os == 'ubuntu-latest'
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-latest
+          - macos-11
           - ubuntu-latest
           # - windows-latest # FIXME
 
@@ -107,7 +107,7 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo
 
-      - if: matrix.os == 'macos-latest'
+      - if: matrix.os == 'macos-11'
         run: brew install ninja
 
       - if: matrix.os == 'ubuntu-latest'

--- a/docs/book/src/developers/ci.md
+++ b/docs/book/src/developers/ci.md
@@ -50,13 +50,13 @@ matrix:
 |--------------------------|----------------------------------|-------------------|
 | **Tier 1**               |                                  |                   |
 | Linux (ubuntu-latest)    | gcc (7-11), clang (7-12)         | x86\_64, i686     |
-| macOS (macos-latest)     | gcc (9-12), clang (11-14)        | x86\_64           |
+| macOS (macos-11)     | gcc (9-12), clang (11-14)        | x86\_64           |
 | Windows (windows-latest) | clang-cl (latest), msvc (latest) | x86\_64, i686     |
 | **Tier 2**               |                                  |                   |
 | Linux (ubuntu-latest)    | gcc (9-12), clang (11-14)        | aarch64           |
-| macOS (macos-latest)     | gcc (9-12), clang (11-14)        | aarch64           |
+| macOS (macos-11)     | gcc (9-12), clang (11-14)        | aarch64           |
 | Android (ubuntu-latest)  | gcc (latest)                     | aarch64           |
-| iOS (macos-latest)       | gcc (9-12), clang (11-14)        | aarch64           |
+| iOS (macos-11)       | gcc (9-12), clang (11-14)        | aarch64           |
 | Linux (ubuntu-latest)    | gcc (latest)                     | s390x             |
 
 Furthermore, on Linux, we test different "editions" of the C programming language, i.e., "msvc".


### PR DESCRIPTION
Github is migrating macos-latest to macos-12 right now. https://github.com/actions/runner-images/issues/6384

The xcode version there (14) appears to have a linker bug https://stackoverflow.com/questions/73734125/xcode-14-0-gcc-12-linker-issue

The CI should be changed back to macos-latest when the bugs are resolved.