### PR TITLE
docs: Update BLAKE2b example.

### DIFF
--- a/tests/blake2b.cc
+++ b/tests/blake2b.cc
@@ -50,8 +50,7 @@ TEST(ApiTestSuite, ApiTest)
     // ANCHOR(example)
     // Reserve memory for a 64 byte digest, i.e.,
     // for a BLAKE2b run with full 512-bit output.
-    uint32_t output_len = 64;
-    uint8_t output[64];
+    uint8_t output[HACL_HASH_BLAKE2B_DIGEST_LENGTH_MAX];
 
     // The message we want to hash.
     const char* message = "Hello, HACL Packages!";
@@ -62,10 +61,14 @@ TEST(ApiTestSuite, ApiTest)
     uint32_t key_len = 0;
     uint8_t* key = 0;
 
-    Hacl_Blake2b_32_blake2b(
-      output_len, output, message_len, (uint8_t*)message, key_len, key);
+    Hacl_Blake2b_32_blake2b(HACL_HASH_BLAKE2B_DIGEST_LENGTH_MAX,
+                            output,
+                            message_len,
+                            (uint8_t*)message,
+                            key_len,
+                            key);
 
-    print_hex_ln(output_len, output);
+    print_hex_ln(HACL_HASH_BLAKE2B_DIGEST_LENGTH_MAX, output);
     // ANCHOR_END(example)
 
     bytes expected_digest = from_hex(


### PR DESCRIPTION
We do not use VLA in our CI (that checks all examples) and C does not have constant expressions. So... when we use a function like `Hacl_Hash_Definitions_hash_len(...)` (instead of `64` as best practice) the example needs to allocate memory at runtime. Which is... not so great. Which brings me to the point: We do need to introduce/cleanup HACL's identifiers.