### PR TITLE
Benchmark pull requests against main

### DIFF
--- a/.github/workflows/benchmark_pull_request.yml
+++ b/.github/workflows/benchmark_pull_request.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build
-          sudo apt-get install python3 python3-scipy
+          sudo apt-get install python3 python3-scipy python3-pandas
 
       - name: Checkout hacl-packages (${{ github.head_ref }})
         uses: actions/checkout@v3

--- a/.github/workflows/benchmark_pull_request.yml
+++ b/.github/workflows/benchmark_pull_request.yml
@@ -37,5 +37,5 @@ jobs:
         run: ./mach build --release --benchmarks
 
       - name: Run benchmarks
-        working-directory: main
-        run: ./mach benchmark --compare ../pr
+        working-directory: pr
+        run: ./mach benchmark --compare ../main

--- a/.github/workflows/benchmark_pull_request.yml
+++ b/.github/workflows/benchmark_pull_request.yml
@@ -36,32 +36,6 @@ jobs:
         working-directory: main
         run: ./mach build --release --benchmarks
 
-      - name: Checkout google/benchmark
-        uses: actions/checkout@v3
-        with:
-          path: gbenchmark
-          repository: google/benchmark
-
       - name: Run benchmarks
-        run: |
-          for f in main/build/Release/*_benchmark
-          do
-            benchmark=$(basename "$f")
-            gbenchmark/tools/compare.py -d "$benchmark.json" benchmarks "main/build/Release/$benchmark" "pr/build/Release/$benchmark"
-          done
-
-      - name: Display results
-        # Display the results dumped by the previous step
-        # Then fail if one of the result is greater than the defined threshold
-        # For a given benchmark, the result is the overall CPU-time evolution
-        run: |
-          ret=0
-          threshold=0.2
-          for f in ./*_benchmark.json
-          do
-            name=$(basename "$f" _benchmark.json)
-            cpu=$(jq '.[-1].measurements[0].cpu' < "$f")
-            printf "%-20s %+.2f\n" "$name" "$cpu"
-            (( $(echo "$cpu > $threshold" | bc) )) && ret=1
-          done
-          exit $ret
+        working-directory: main
+        run: ./mach benchmark --compare ../pr

--- a/.github/workflows/benchmark_pull_request.yml
+++ b/.github/workflows/benchmark_pull_request.yml
@@ -51,15 +51,15 @@ jobs:
           done
 
       - name: Display results
+        # Display the results dumped by the previous step
+        # Then fail if one of the result is greater than the defined threshold
+        # For a given benchmark, the result is the overall CPU-time evolution
         run: |
-          # Display the results dumped by the previous step
-          # Then fail if one of the result is greater than the defined threshold
           ret=0
           threshold=0.2
           for f in ./*_benchmark.json
           do
             name=$(basename "$f" _benchmark.json)
-            # For a given benchmark, the result is the overall CPU-time evolution
             cpu=$(jq '.[-1].measurements[0].cpu' < "$f")
             printf "%-20s %+.2f\n" "$name" "$cpu"
             (( $(echo "$cpu > $threshold" | bc) )) && ret=1

--- a/.github/workflows/benchmark_pull_request.yml
+++ b/.github/workflows/benchmark_pull_request.yml
@@ -1,0 +1,64 @@
+name: benchmark_pull_request
+
+on:
+  push:
+    branches:
+      - 'hacl-star-**'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  default:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        run: |
+          sudo apt-get update
+          sudo apt-get install ninja-build
+          sudo apt-get install python3 python3-scipy
+
+      - name: Checkout hacl-packages
+        uses: actions/checkout@v3
+        with:
+          path: pr
+
+      - name: Build hacl-packages
+        working-directory: pr
+        run: ./mach build --release --benchmarks
+
+      - name: Checkout hacl-packages main
+        uses: actions/checkout@v3
+        with:
+          path: main
+          ref: main
+
+      - name: Build hacl-packages main
+        working-directory: main
+        run: ./mach build --release --benchmarks
+
+      - name: Checkout google/benchmark
+        uses: actions/checkout@v3
+        with:
+          path: gbenchmark
+          repository: google/benchmark
+
+      - name: Run benchmarks
+        run: |
+          for f in main/build/Release/*_benchmark
+          do
+            benchmark=$(basename "$f")
+            gbenchmark/tools/compare.py -d "$benchmark.json" benchmarks "main/build/Release/$benchmark" "pr/build/Release/$benchmark"
+          done
+
+      - name: Display results
+        run: |
+          ret=0
+          threshold=0.2
+          for f in ./*_benchmark.json
+          do
+            name=$(basename "$f" _benchmark.json)
+            cpu=$(jq '.[-1].measurements[0].cpu' < "$f")
+            printf "%-20s %+.2f\n" "$name" "$cpu"
+            (( $(echo "$cpu > $threshold" | bc) )) && ret=1
+          done
+          exit $ret

--- a/.github/workflows/benchmark_pull_request.yml
+++ b/.github/workflows/benchmark_pull_request.yml
@@ -17,22 +17,22 @@ jobs:
           sudo apt-get install ninja-build
           sudo apt-get install python3 python3-scipy
 
-      - name: Checkout hacl-packages
+      - name: Checkout hacl-packages (${{ github.head_ref }})
         uses: actions/checkout@v3
         with:
           path: pr
 
-      - name: Build hacl-packages
+      - name: Build hacl-packages (${{ github.head_ref }})
         working-directory: pr
         run: ./mach build --release --benchmarks
 
-      - name: Checkout hacl-packages main
+      - name: Checkout hacl-packages (main)
         uses: actions/checkout@v3
         with:
           path: main
           ref: main
 
-      - name: Build hacl-packages main
+      - name: Build hacl-packages (main)
         working-directory: main
         run: ./mach build --release --benchmarks
 
@@ -52,11 +52,14 @@ jobs:
 
       - name: Display results
         run: |
+          # Display the results dumped by the previous step
+          # Then fail if one of the result is greater than the defined threshold
           ret=0
           threshold=0.2
           for f in ./*_benchmark.json
           do
             name=$(basename "$f" _benchmark.json)
+            # For a given benchmark, the result is the overall CPU-time evolution
             cpu=$(jq '.[-1].measurements[0].cpu' < "$f")
             printf "%-20s %+.2f\n" "$name" "$cpu"
             (( $(echo "$cpu > $threshold" | bc) )) && ret=1

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -84,7 +84,7 @@ def compare_benchmarks(benchmarks, path_1, path_2):
             subprocess.run(benchmark_cmd)
 
     threshold = 0.2
-    ret = 0
+    fail = false
     for algorithm in benchmarks:
         for benchmark in benchmarks[algorithm]:
             file_name = Path(benchmark).stem
@@ -96,9 +96,10 @@ def compare_benchmarks(benchmarks, path_1, path_2):
             print("{:20} {:+0.2f}".format(file_name, result))
             # If one result is greater than the threshold, the command fails
             if result > threshold:
-                ret = 1
-
-    exit(ret)
+                fail = true
+    if fail:
+        print("! Threshold exceeded!")
+        exit(1)
 
 
 @subcommand(

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -107,7 +107,7 @@ def compare_benchmarks(benchmarks, path_1, path_2):
         argument(
             "-v", "--verbose", help="Make benchmarks verbose.", action="store_true"
         ),
-        argument("--compare", help="Compare against another revision.", type=str),
+        argument("--compare", help="Compare against an older revision.", type=str),
     ]
 )
 def benchmark(args):

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -38,11 +38,73 @@ def run_benchmarks(benchmarks, bin_path):
             subprocess.run(benchmark_cmd, check=True)
 
 
+def compare_benchmarks(benchmarks, path_1, path_2):
+    print("Comparing benchmarks ...")
+
+    if not os.path.exists(path_1) or not os.path.exists(path_2):
+        print("! Nothing is built! Please build first. Aborting!")
+        exit(1)
+    if not os.path.exists("build/benchmark-src"):
+        print("! gbenchmark missing! Aborting!")
+        exit(1)
+
+    compare = "./build/benchmark-src/tools/compare.py"
+
+    for algorithm in benchmarks:
+        for benchmark in benchmarks[algorithm]:
+
+            file_name = Path(benchmark).stem
+            file_name_1 = os.path.join(path_1, file_name + "_benchmark")
+            file_name_2 = os.path.join(path_2, file_name + "_benchmark")
+            if sys.platform == "win32":
+                file_name_1 += ".exe"
+                file_name_2 += ".exe"
+            if not os.path.exists(file_name_1):
+                print("! Benchmark '%s' doesn't exist. Aborting!" % (file_name_1))
+                print("   Running this benchmark requires a build first.")
+                print("   See mach build --help")
+                exit(1)
+            if not os.path.exists(file_name_2):
+                print("! Benchmark '%s' doesn't exist. Aborting!" % (file_name_2))
+                print("   Running this benchmark requires a build first.")
+                print("   See mach build --help")
+                exit(1)
+            out_path = os.path.join(path_1, file_name + "_benchmark.json")
+            benchmark_cmd = [
+                compare,
+                "-d",
+                os.path.join(".", out_path),
+                "benchmarks",
+                os.path.join(".", file_name_1),
+                file_name_2,
+            ]
+            print(" ".join(benchmark_cmd))
+            subprocess.run(benchmark_cmd)
+
+    threshold = 0.2
+    ret = 0
+    for algorithm in benchmarks:
+        for benchmark in benchmarks[algorithm]:
+            file_name = Path(benchmark).stem
+            out_path = os.path.join(path_1, file_name + "_benchmark.json")
+            f = open(out_path)
+            data = json.load(f)
+            # For each benchmark, the result is the overall CPU-time evolution
+            result = data[-1]["measurements"][0]["cpu"]
+            print("{:20} {:+0.2f}".format(file_name, result))
+            # If one result is greater than the threshold, the command fails
+            if result > threshold:
+                ret = 1
+
+    exit(ret)
+
+
 @subcommand(
     [
         argument(
             "-v", "--verbose", help="Make benchmarks verbose.", action="store_true"
         ),
+        argument("--compare", help="Compare against another revision.", type=str),
     ]
 )
 def benchmark(args):
@@ -55,4 +117,11 @@ def benchmark(args):
     # parse file
     config = json.loads(data)
 
-    run_benchmarks(config["benchmarks"], "Release")
+    if args.compare:
+        compare_benchmarks(
+            config["benchmarks"],
+            binary_path("Release"),
+            os.path.join(args.compare, binary_path("Release")),
+        )
+    else:
+        run_benchmarks(config["benchmarks"], "Release")

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -77,8 +77,8 @@ def compare_benchmarks(benchmarks, path_1, path_2):
                 "-d",
                 os.path.join(".", out_path),
                 "benchmarks",
-                os.path.join(".", file_name_1),
                 file_name_2,
+                os.path.join(".", file_name_1),
             ]
             print(" ".join(benchmark_cmd))
             subprocess.run(benchmark_cmd)

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -84,7 +84,7 @@ def compare_benchmarks(benchmarks, path_1, path_2):
             subprocess.run(benchmark_cmd)
 
     threshold = 0.2
-    fail = false
+    fail = False
     for algorithm in benchmarks:
         for benchmark in benchmarks[algorithm]:
             file_name = Path(benchmark).stem
@@ -96,7 +96,7 @@ def compare_benchmarks(benchmarks, path_1, path_2):
             print("{:20} {:+0.2f}".format(file_name, result))
             # If one result is greater than the threshold, the command fails
             if result > threshold:
-                fail = true
+                fail = True
     if fail:
         print("! Threshold exceeded!")
         exit(1)

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -42,7 +42,9 @@ def compare_benchmarks(benchmarks, path_1, path_2):
     print("Comparing benchmarks ...")
 
     if not os.path.exists(path_1) or not os.path.exists(path_2):
-        print("! Nothing is built! Please build first. Aborting!")
+        print(
+            "! Build missing! Please build both revisions first: `./mach build --release --benchmarks`. Aborting!"
+        )
         exit(1)
     if not os.path.exists("build/benchmark-src"):
         print("! gbenchmark missing! Aborting!")


### PR DESCRIPTION
This PR adds the `--compare` flag to the `./mach benchmark` subcommand, allowing to benchmark against another revision of hacl-packages.
It also adds a github action that will use that command on PRs and hacl-star branches, comparing them with `main`.