### PR TITLE
docs: Switch to #defines in older examples. (+ minor fix)

### DIFF
--- a/docs/reference/hacl/aead/chacha20poly1305.md
+++ b/docs/reference/hacl/aead/chacha20poly1305.md
@@ -41,9 +41,14 @@ Support for VEC256 is needed. Please see the [HACL Packages book].
 
 ## API Reference
 
-`````{tabs}
-````{group-tab} 32
-**Example**
+**Example (32)**
+
+```{literalinclude} ../../../../tests/chacha20poly1305.cc
+:language: C
+:dedent:
+:start-after: "// ANCHOR(DEFINE)"
+:end-before: "// ANCHOR_END(DEFINE)"
+```
 
 ```{literalinclude} ../../../../tests/chacha20poly1305.cc
 :language: C
@@ -52,26 +57,20 @@ Support for VEC256 is needed. Please see the [HACL Packages book].
 :end-before: "// END OneShot"
 ```
 
+`````{tabs}
+````{group-tab} 32
 ```{doxygenfunction} Hacl_Chacha20Poly1305_32_aead_encrypt
 ```
 ```{doxygenfunction} Hacl_Chacha20Poly1305_32_aead_decrypt
 ```
 ````
 ````{group-tab} 128
-**Example**
-
-There is no example for now.
-
 ```{doxygenfunction} Hacl_Chacha20Poly1305_128_aead_encrypt
 ```
 ```{doxygenfunction} Hacl_Chacha20Poly1305_128_aead_decrypt
 ```
 ````
 ````{group-tab} 256
-**Example**
-
-There is no example for now.
-
 ```{doxygenfunction} Hacl_Chacha20Poly1305_256_aead_encrypt
 ```
 ```{doxygenfunction} Hacl_Chacha20Poly1305_256_aead_decrypt

--- a/docs/reference/hacl/hash/sha1.md
+++ b/docs/reference/hacl/hash/sha1.md
@@ -13,6 +13,13 @@ SHA-1 is insecure. Please avoid or ask your cryptographer of trust for permissio
 ```{literalinclude} ../../../../tests/sha1.cc
 :language: C
 :dedent:
+:start-after: "// ANCHOR(example define)"
+:end-before: "// ANCHOR_END(example define)"
+```
+
+```{literalinclude} ../../../../tests/sha1.cc
+:language: C
+:dedent:
 :start-after: "// START OneShot"
 :end-before: "// END OneShot"
 ```

--- a/docs/reference/hacl/hash/sha2.md
+++ b/docs/reference/hacl/hash/sha2.md
@@ -23,6 +23,13 @@ it is sometimes called `SHA2-256` to avoid confusion with SHA-1 and SHA-3.
 ```{literalinclude} ../../../../tests/sha2.cc
 :language: C
 :dedent:
+:start-after: "// ANCHOR(example define)"
+:end-before: "// ANCHOR_END(example define)"
+```
+
+```{literalinclude} ../../../../tests/sha2.cc
+:language: C
+:dedent:
 :start-after: "// START OneShot"
 :end-before: "// END OneShot"
 ```

--- a/docs/reference/hacl/hash/sha3.md
+++ b/docs/reference/hacl/hash/sha3.md
@@ -21,6 +21,13 @@ SHAKE128 and SHAKE256 have a 128- or 256-bit security strength and can produce a
 ```{literalinclude} ../../../../tests/sha3.cc
 :language: C
 :dedent:
+:start-after: "// ANCHOR(example define)"
+:end-before: "// ANCHOR_END(example define)"
+```
+
+```{literalinclude} ../../../../tests/sha3.cc
+:language: C
+:dedent:
 :start-after: "// START OneShot"
 :end-before: "// END OneShot"
 ```

--- a/docs/reference/hacl/nacl/skae/index.md
+++ b/docs/reference/hacl/nacl/skae/index.md
@@ -12,6 +12,20 @@ Thus, the message and ciphertext are allowed to overlap.
 
 ### Combined mode
 
+```{literalinclude} ../../../../../tests/nacl.cc
+:language: C
+:dedent:
+:start-after: "// ANCHOR(EXAMPLE SETUP SECRETBOX)"
+:end-before: "// ANCHOR_END(EXAMPLE SETUP SECRETBOX)"
+```
+
+```{literalinclude} ../../../../../tests/nacl.cc
+:language: C
+:dedent:
+:start-after: "// ANCHOR(EXAMPLE SECRET EASY)"
+:end-before: "// ANCHOR_END(EXAMPLE SECRET EASY)"
+```
+
 In combined mode, the authentication tag and encrypted message are stored consecutively in memory.
 Thus, `c` must always point to memory with length 16 (tag length) + `mlen` (message length).
 
@@ -22,6 +36,20 @@ Thus, `c` must always point to memory with length 16 (tag length) + `mlen` (mess
 ```
 
 ### Detached mode
+
+```{literalinclude} ../../../../../tests/nacl.cc
+:language: C
+:dedent:
+:start-after: "// ANCHOR(EXAMPLE SETUP SECRETBOX)"
+:end-before: "// ANCHOR_END(EXAMPLE SETUP SECRETBOX)"
+```
+
+```{literalinclude} ../../../../../tests/nacl.cc
+:language: C
+:dedent:
+:start-after: "// ANCHOR(EXAMPLE SECRET DETACHED)"
+:end-before: "// ANCHOR_END(EXAMPLE SECRET DETACHED)"
+```
 
 In detached mode, the authentication tag and encrypted message are stored separately.
 Thus, `c` must always point to `mlen` bytes and `tag` must always point to 16 (tag length) bytes.

--- a/docs/reference/hacl/signature/eddsa.md
+++ b/docs/reference/hacl/signature/eddsa.md
@@ -16,6 +16,13 @@ Two APIs are exposed: A (simple) "One-Shot" API to sign/verify a single message 
 ```{literalinclude} ../../../../tests/ed25519.cc
 :language: C
 :dedent:
+:start-after: "// ANCHOR(DEFINE)"
+:end-before: "// ANCHOR_END(DEFINE)"
+```
+
+```{literalinclude} ../../../../tests/ed25519.cc
+:language: C
+:dedent:
 :start-after: "// ANCHOR(example)"
 :end-before: "// ANCHOR_END(example)"
 ```
@@ -29,6 +36,13 @@ Two APIs are exposed: A (simple) "One-Shot" API to sign/verify a single message 
 ### Precomputed
 
 **Example**
+
+```{literalinclude} ../../../../tests/ed25519.cc
+:language: C
+:dedent:
+:start-after: "// ANCHOR(DEFINE)"
+:end-before: "// ANCHOR_END(DEFINE)"
+```
 
 ```{literalinclude} ../../../../tests/ed25519.cc
 :language: C

--- a/tests/chacha20poly1305.cc
+++ b/tests/chacha20poly1305.cc
@@ -85,6 +85,13 @@ print_test(test_encrypt aead_encrypt,
 
 // -----------------------------------------------------------------------------
 
+// ANCHOR(DEFINE)
+// HACL* will define these (or something similar) in a future version.
+#define HACL_AEAD_CHACHA20_POLY1305_KEY_LEN 32
+#define HACL_AEAD_CHACHA20_POLY1305_NONCE_LEN 12
+#define HACL_AEAD_CHACHA20_POLY1305_MAC_LEN 16
+// ANCHOR_END(DEFINE)
+
 TEST(ApiSuite, ApiTest)
 {
   // Documentation.
@@ -94,12 +101,12 @@ TEST(ApiSuite, ApiTest)
     // Note: This is only an example, and you must bring your own random.
 
     // Create a key ...
-    uint8_t key[32];
-    generate_random(key, 32);
+    uint8_t key[HACL_AEAD_CHACHA20_POLY1305_KEY_LEN];
+    generate_random(key, HACL_AEAD_CHACHA20_POLY1305_KEY_LEN);
 
     // ... and a nonce.
-    uint8_t nonce[12];
-    generate_random(nonce, 12);
+    uint8_t nonce[HACL_AEAD_CHACHA20_POLY1305_NONCE_LEN];
+    generate_random(nonce, HACL_AEAD_CHACHA20_POLY1305_NONCE_LEN);
 
     // We don't authenticate additional data in this example.
     const char* aad = "";
@@ -109,23 +116,31 @@ TEST(ApiSuite, ApiTest)
     const char* msg = "Hello, World!";
     const uint32_t msg_len = strlen(msg);
 
-    // We need to allocate the same amount of memory for the ciphertext as for the plaintext ...
+    // We need to allocate the same amount of memory for the ciphertext as for
+    // the plaintext ...
     uint8_t* cipher = (uint8_t*)malloc(msg_len);
     // ... and also need to provide additional memory for the mac.
-    // Note that encyption and decryption can also be done in-place, i.e., cipher and plaintext can
-    // point to the same memory.
-    uint8_t mac[16];
+    // Note that encyption and decryption can also be done in-place, i.e.,
+    // cipher and plaintext can point to the same memory.
+    uint8_t mac[HACL_AEAD_CHACHA20_POLY1305_MAC_LEN];
 
     // Encryption.
     Hacl_Chacha20Poly1305_32_aead_encrypt(
       key, nonce, aad_len, (uint8_t*)aad, msg_len, (uint8_t*)msg, cipher, mac);
 
     // Decryption.
-    // Allocate the same amount of memory for the recovered message as for the ciphertext.
+    // Allocate the same amount of memory for the recovered message as for the
+    // ciphertext.
     uint8_t* recovered = (uint8_t*)malloc(msg_len);
 
-    uint32_t res = Hacl_Chacha20Poly1305_32_aead_decrypt(
-      key, nonce, aad_len, (uint8_t*)aad, msg_len, (uint8_t*)recovered, cipher, mac);
+    uint32_t res = Hacl_Chacha20Poly1305_32_aead_decrypt(key,
+                                                         nonce,
+                                                         aad_len,
+                                                         (uint8_t*)aad,
+                                                         msg_len,
+                                                         (uint8_t*)recovered,
+                                                         cipher,
+                                                         mac);
 
     if (res == 0) {
       printf("Decryption successful.");

--- a/tests/ed25519.cc
+++ b/tests/ed25519.cc
@@ -94,6 +94,13 @@ read_wycheproof_eddsa_verify(string path)
 
 // -----------------------------------------------------------------------------
 
+// ANCHOR(DEFINE)
+#define HACL_SIGNATURE_ED25519_SECRETKEY_LEN 32
+#define HACL_SIGNATURE_ED25519_SECRETKEY_PRECOMP_LEN 96
+#define HACL_SIGNATURE_ED25519_PUBLICKEY_LEN 32
+#define HACL_SIGNATURE_ED25519_SIGNATURE_LEN 64
+// ANCHOR_END(DEFINE)
+
 TEST(ApiTestSuite, ApiTest)
 {
   {
@@ -109,18 +116,19 @@ TEST(ApiTestSuite, ApiTest)
     //       The `generate_random` function is only used as an
     //       example, and you must bring your own random.
     // 1) Create a secret key.
-    uint8_t sk[32];
-    generate_random(sk, 32);
+    uint8_t sk[HACL_SIGNATURE_ED25519_SECRETKEY_LEN];
+    generate_random(sk, HACL_SIGNATURE_ED25519_SECRETKEY_LEN);
 
     // 2) Derive a public key from the secret key.
-    uint8_t pk[32];
+    uint8_t pk[HACL_SIGNATURE_ED25519_PUBLICKEY_LEN];
     Hacl_Ed25519_secret_to_public(pk, sk);
 
     // Then, we can sign a message.
     // 1) Create a message and allocate memory for the signature.
     uint8_t msg[123];
     generate_random(msg, 123);
-    uint8_t signature[64];
+
+    uint8_t signature[HACL_SIGNATURE_ED25519_SIGNATURE_LEN];
 
     // 2) Sign the message with the private key.
     Hacl_Ed25519_sign(signature, sk, 123, msg);
@@ -151,11 +159,11 @@ TEST(ApiTestSuite, ApiTest)
     //
     //       The `generate_random` function is only used as an
     //       example, and you must bring your own random.
-    uint8_t sk[32];
-    generate_random(sk, 32);
+    uint8_t sk[HACL_SIGNATURE_ED25519_SECRETKEY_LEN];
+    generate_random(sk, HACL_SIGNATURE_ED25519_SECRETKEY_LEN);
 
     // Then, we precompute an intermediate key that will be used for signing.
-    uint8_t sk_exp[96];
+    uint8_t sk_exp[HACL_SIGNATURE_ED25519_SECRETKEY_PRECOMP_LEN];
     Hacl_Ed25519_expand_keys(sk_exp, sk);
 
     // Finally, we use the precomputed key to sign (multiple) messages.
@@ -164,14 +172,14 @@ TEST(ApiTestSuite, ApiTest)
     uint8_t msg_2[42];
     generate_random(msg_2, 42);
 
-    uint8_t signature_1[64];
-    uint8_t signature_2[64];
+    uint8_t signature_1[HACL_SIGNATURE_ED25519_SIGNATURE_LEN];
+    uint8_t signature_2[HACL_SIGNATURE_ED25519_SIGNATURE_LEN];
 
     Hacl_Ed25519_sign_expanded(signature_1, sk_exp, 1337, msg_1);
     Hacl_Ed25519_sign_expanded(signature_2, sk_exp, 42, msg_2);
     // ANCHOR_END(example precomputed)
 
-    uint8_t pk[32];
+    uint8_t pk[HACL_SIGNATURE_ED25519_PUBLICKEY_LEN];
     Hacl_Ed25519_secret_to_public(pk, sk);
 
     bool result_1 = Hacl_Ed25519_verify(pk, 1337, msg_1, signature_1);

--- a/tests/nacl.cc
+++ b/tests/nacl.cc
@@ -240,7 +240,6 @@ TEST(ApiSuite, ApiTest)
 
   {
     // ANCHOR(EXAMPLE SECRET EASY)
-    // Encrypt
     const char* plaintext = "Hello, World!";
     const size_t plaintext_size = strlen(plaintext);
 
@@ -273,7 +272,6 @@ TEST(ApiSuite, ApiTest)
 
   {
     // ANCHOR(EXAMPLE SECRET DETACHED)
-    // Encrypt
     const char* plaintext = "Hello, World!";
     const size_t plaintext_size = strlen(plaintext);
 

--- a/tests/sha1.cc
+++ b/tests/sha1.cc
@@ -74,8 +74,7 @@ TEST(ApiSuite, ApiTest)
     const char* message = "Hello, World!";
     uint32_t message_size = strlen(message);
 
-    // 160 Bit / 8 = 20 Byte
-    uint8_t digest[160 / 8];
+    uint8_t digest[HACL_HASH_SHA1_DIGEST_LENGTH];
 
     Hacl_Hash_SHA1_legacy_hash((uint8_t*)message, message_size, digest);
     // END OneShot
@@ -83,7 +82,7 @@ TEST(ApiSuite, ApiTest)
     bytes expected_digest =
       from_hex("0a0a9f2a6772942557ab5355d76af442f8f65e01");
 
-    EXPECT_EQ(strncmp((char*)digest, (char*)expected_digest.data(), 20), 0);
+    EXPECT_EQ(strncmp((char*)digest, (char*)expected_digest.data(), HACL_HASH_SHA1_DIGEST_LENGTH), 0);
   }
 
   // Documentation.

--- a/tests/sha2.cc
+++ b/tests/sha2.cc
@@ -78,8 +78,7 @@ TEST(ApiSuite, ApiTest)
     const char* message = "Hello, World!";
     uint32_t message_size = strlen(message);
 
-    // 256 Bit / 8 = 32 Byte
-    uint8_t digest[256 / 8];
+    uint8_t digest[HACL_HASH_SHA2_256_DIGEST_LENGTH];
 
     Hacl_Hash_SHA2_hash_256((uint8_t*)message, message_size, digest);
     // END OneShot
@@ -87,7 +86,10 @@ TEST(ApiSuite, ApiTest)
     bytes expected_digest = from_hex(
       "dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f");
 
-    EXPECT_EQ(strncmp((char*)digest, (char*)expected_digest.data(), 32), 0);
+    EXPECT_EQ(strncmp((char*)digest,
+                      (char*)expected_digest.data(),
+                      HACL_HASH_SHA2_256_DIGEST_LENGTH),
+              0);
   }
 
   // Documentation.

--- a/tests/sha3.cc
+++ b/tests/sha3.cc
@@ -64,8 +64,7 @@ TEST(ApiSuite, ApiTest)
     const char* message = "Hello, World!";
     uint32_t message_size = strlen(message);
 
-    // 256 Bit / 8 = 32 Byte
-    uint8_t digest[256 / 8];
+    uint8_t digest[HACL_HASH_SHA3_256_DIGEST_LENGTH];
 
     Hacl_SHA3_sha3_256(message_size, (uint8_t*)message, digest);
     // END OneShot
@@ -73,7 +72,10 @@ TEST(ApiSuite, ApiTest)
     bytes expected_digest = from_hex(
       "1af17a664e3fa8e419b8ba05c2a173169df76162a5a286e0c405b460d478f7ef");
 
-    EXPECT_EQ(strncmp((char*)digest, (char*)expected_digest.data(), 32), 0);
+    EXPECT_EQ(strncmp((char*)digest,
+                      (char*)expected_digest.data(),
+                      HACL_HASH_SHA3_256_DIGEST_LENGTH),
+              0);
   }
 
   // Documentation.


### PR DESCRIPTION
This closes #285. Btw., this is the last issue I was assigned on that is part of the documentation milestone for HACL Packages 🎉 

(There are other documentation issues but nothing that we could tackle before the API redesign, IMO.)