### PR TITLE
job to build docs for ocaml tags

### DIFF
--- a/.github/workflows/ocaml-docs.yml
+++ b/.github/workflows/ocaml-docs.yml
@@ -1,0 +1,69 @@
+name: Deploy OCaml docs for all Releases
+
+on:
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Checkout | Fetch tags
+        run: git fetch --tags origin
+
+      - name: Setup | Update
+        run: sudo apt-get update
+
+      - name: Setup | System
+        run: sudo apt-get install opam libgmp-dev ninja-build
+
+      - name: Setup | OCaml
+        run: |
+          opam init --auto-setup --disable-sandboxing --yes --bare
+          opam switch create 4.12.0 --yes
+          eval $(opam env)
+          opam install --yes ocamlfind odoc ctypes zarith cppo dune
+
+      - name: Setup | Pages
+        uses: actions/configure-pages@v2
+
+      - name: Build | OCaml API Reference for Tags
+        run: |
+          mkdir -p build/ocaml
+          for branch in $(git for-each-ref --format='%(refname)' refs/tags/); do
+            if [[ "$branch" == *"ocaml-"* ]]; then
+              rm -rf opam
+              tag=$(echo $branch | cut -d'/' -f 3)
+              git checkout $tag
+              echo "Building documentation for $tag"
+              mkdir -p build/ocaml/$tag
+              ./opam.sh
+              cd opam
+              eval $(opam env)
+              opam install . --yes --assume-depexts
+              dune build @doc --only-packages=hacl-star
+              cp -r _build/default/_doc/_html/* ../build/ocaml/$tag/
+              cd ../
+            fi
+          done
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: "build"
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -30,3 +30,4 @@
     - [OCaml](./developers/ocaml-build.md)
   - [Continuous Integration](./developers/ci.md)
   - [Documentation](./developers/documentation.md)
+    - [OCaml](./developers/ocaml-docs.md)

--- a/docs/book/src/developers/ocaml-docs.md
+++ b/docs/book/src/developers/ocaml-docs.md
@@ -7,6 +7,6 @@ The [ocaml-docs] workflow can be used to generate documentation for all `ocaml-`
 
 When creating a new release an `ocaml-` tag with the new version number is created.
 (1) After creating the tag the [ocaml-docs] job must be triggered to create the new, tagged ocaml documentation.
-(2) After creating the docs, a link to them must be added to the table in `hacl-ocam/readme.md`.
+(2) After creating the docs, a link to them must be added to the table in `hacl-ocaml/readme.md`.
 
 [ocaml-docs]: https://github.com/cryspen/hacl-packages/actions/workflows/ocaml-docs.yml

--- a/docs/book/src/developers/ocaml-docs.md
+++ b/docs/book/src/developers/ocaml-docs.md
@@ -1,0 +1,12 @@
+# OCaml Docs
+
+The OCaml documentation system (odoc) doesn't support documenting multiple versions.
+The [ocaml-docs] workflow can be used to generate documentation for all `ocaml-` tags (releases).
+
+## Creating a new release
+
+When creating a new release an `ocaml-` tag with the new version number is created.
+(1) After creating the tag the [ocaml-docs] job must be triggered to create the new, tagged ocaml documentation.
+(2) After creating the docs, a link to them must be added to the table in `hacl-ocam/readme.md`.
+
+[ocaml-docs]: https://github.com/cryspen/hacl-packages/actions/workflows/ocaml-docs.yml

--- a/docs/book/src/hacl-ocaml/readme.md
+++ b/docs/book/src/hacl-ocaml/readme.md
@@ -1,5 +1,27 @@
 # OCaml Package
 
 For more information on the OCaml package please
-* check out the latest documentation: [HACL Packages API Reference (main)](../ocaml/main/index.html) 📚
-* the [opam package](https://opam.ocaml.org/packages/hacl-star/) 📦 
+
+- check out the latest documentation: [HACL Packages API Reference (main)](../ocaml/main/index.html) 📚
+- the [opam package](https://opam.ocaml.org/packages/hacl-star/) 📦 (latest release)
+
+## Releases
+
+See [Changes.md] for changes between the versions.
+
+| Version | Package 📦    | Docs 📚       |
+| ------- | ------------- | ------------- |
+| 0.6.2   | [opam v0.6.2] | [Docs v0.6.2] |
+| 0.6.1   | [opam v0.6.1] | [Docs v0.6.1] |
+| 0.6.0   | [opam v0.6.0] | [Docs v0.6.0] |
+| 0.5.0   | [opam v0.5.0] | [Docs v0.5.0] |
+
+[changes.md]: https://github.com/cryspen/hacl-packages/blob/main/ocaml/hacl-star/CHANGES.md
+[opam v0.5.0]: https://opam.ocaml.org/packages/hacl-star/hacl-star.0.5.0/
+[opam v0.6.0]: https://opam.ocaml.org/packages/hacl-star/hacl-star.0.6.0/
+[opam v0.6.1]: https://opam.ocaml.org/packages/hacl-star/hacl-star.0.6.1/
+[opam v0.6.2]: https://opam.ocaml.org/packages/hacl-star/hacl-star.0.6.2/
+[docs v0.5.0]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.5.0/index.html
+[docs v0.6.0]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.6.0/index.html
+[docs v0.6.1]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.6.1/index.html
+[docs v0.6.2]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.6.2/index.html


### PR DESCRIPTION
The book describes how to build ocaml docs for tags and where to add the links.
It's not fully automated. But I think this should be good enough for now as it's only needed for new releases (it could also be improved to build only new docs).

I can't test this until it's merged (deployment only works on main). But the [last job] worked as expected.

Fixes #227 

[last job]: https://github.com/cryspen/hacl-packages/actions/runs/3697819479