### PR TITLE
Better integrate cmake example

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -27,7 +27,7 @@ jobs:
         os:
           - macos-11
           - ubuntu-latest
-          - windows-latest
+          # - windows-latest
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -14,6 +14,7 @@ on:
       - LICENSE-APACHE
       - README.md
   workflow_dispatch:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,60 @@
+name: examples
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - .gitignore
+      - CLA.md
+      - CODE_OF_CONDUCT.md
+      - CONTRIBUTING.md
+      - cpu-features.md
+      - LICENSE
+      - LICENSE-APACHE
+      - README.md
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cmake:
+    strategy:
+      matrix:
+        os:
+          - macos-11
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Ubuntu
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install ninja-build
+
+      - name: Setup macOS
+        if: matrix.os == 'macos-11'
+        run: brew install ninja
+
+      - name: Setup Windows - MSVC
+        if: ${{ matrix.os == 'windows-latest' }}
+        uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d
+        with:
+          arch: x64
+
+      - name: Setup Windows - Ninja
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: choco install ninja
+
+      - name: Blake2 Example
+        working-directory: examples/cmake
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build .
+          ./example

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -16,6 +16,7 @@
 # Packages
 
 - [C](./hacl-c/readme.md)
+  - [CMake](./hacl-c/cmake.md)
 - [Rust](./hacl-rust/readme.md)
   <!-- - [AEADs](./hacl-rust/aead.md) -->
 - [OCaml](./hacl-ocaml/readme.md)

--- a/docs/book/src/hacl-c/cmake.md
+++ b/docs/book/src/hacl-c/cmake.md
@@ -1,0 +1,14 @@
+# CMake
+
+You can include HACL Packages in your CMake project using `FetchContent`.
+
+The `CMakeLists.txt` could look like this.
+To use a specific release change the `GIT_TAG` to the release tag.
+
+```
+{{#include ../../../../examples/cmake/CMakeLists.txt}}
+```
+
+You can find the full example in [examples/cmake].
+
+[examples/cmake]: https://github.com/cryspen/hacl-packages/tree/main/examples/cmake


### PR DESCRIPTION
- Describe how to use HACL in a CMake project in the book.
- Run the cmake example on CI

No windows in CI for now (it's failing and needs debugging).

Fixes #268