### PR TITLE
use `github.ref` instead of `github.head_ref`

### DIFF
--- a/.github/workflows/benchmark_pull_request.yml
+++ b/.github/workflows/benchmark_pull_request.yml
@@ -17,12 +17,12 @@ jobs:
           sudo apt-get install ninja-build
           sudo apt-get install python3 python3-scipy python3-pandas
 
-      - name: Checkout hacl-packages (${{ github.head_ref }})
+      - name: Checkout hacl-packages (${{ github.ref }})
         uses: actions/checkout@v3
         with:
           path: pr
 
-      - name: Build hacl-packages (${{ github.head_ref }})
+      - name: Build hacl-packages (${{ github.ref }})
         working-directory: pr
         run: ./mach build --release --benchmarks
 


### PR DESCRIPTION
`github.head_ref` only works when the action is triggered by a pull request, but the `benchmark_pull_request` action is also triggered by `hacl-star-**` branches, thus we need to use `github.ref` instead.