### PR TITLE
fix benchmark comparison

### DIFF
--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -38,10 +38,10 @@ def run_benchmarks(benchmarks, bin_path):
             subprocess.run(benchmark_cmd, check=True)
 
 
-def compare_benchmarks(benchmarks, path_1, path_2):
+def compare_benchmarks(benchmarks, path_new, path_old):
     print("Comparing benchmarks ...")
 
-    if not os.path.exists(path_1) or not os.path.exists(path_2):
+    if not os.path.exists(path_new) or not os.path.exists(path_old):
         print(
             "! Build missing! Please build both revisions first: `./mach build --release --benchmarks`. Aborting!"
         )
@@ -56,29 +56,27 @@ def compare_benchmarks(benchmarks, path_1, path_2):
         for benchmark in benchmarks[algorithm]:
 
             file_name = Path(benchmark).stem
-            file_name_1 = os.path.join(path_1, file_name + "_benchmark")
-            file_name_2 = os.path.join(path_2, file_name + "_benchmark")
+            file_name_new = os.path.join(path_new, file_name + "_benchmark")
+            file_name_old = os.path.join(path_old, file_name + "_benchmark")
             if sys.platform == "win32":
-                file_name_1 += ".exe"
-                file_name_2 += ".exe"
-            if not os.path.exists(file_name_1):
-                print("! Benchmark '%s' doesn't exist. Aborting!" % (file_name_1))
+                file_name_new += ".exe"
+                file_name_old += ".exe"
+            if not os.path.exists(file_name_new):
+                print("! Benchmark '%s' doesn't exist. Aborting!" % (file_name_new))
                 print("   Running this benchmark requires a build first.")
                 print("   See mach build --help")
                 exit(1)
-            if not os.path.exists(file_name_2):
-                print("! Benchmark '%s' doesn't exist. Aborting!" % (file_name_2))
-                print("   Running this benchmark requires a build first.")
-                print("   See mach build --help")
-                exit(1)
-            out_path = os.path.join(path_1, file_name + "_benchmark.json")
+            if not os.path.exists(file_name_old):
+                print("! Benchmark '%s' doesn't exist!" % (file_name_old))
+                continue
+            out_path = os.path.join(path_new, file_name + "_benchmark.json")
             benchmark_cmd = [
                 compare,
                 "-d",
                 os.path.join(".", out_path),
                 "benchmarks",
-                file_name_2,
-                os.path.join(".", file_name_1),
+                file_name_old,
+                os.path.join(".", file_name_new),
             ]
             print(" ".join(benchmark_cmd))
             subprocess.run(benchmark_cmd)
@@ -88,7 +86,9 @@ def compare_benchmarks(benchmarks, path_1, path_2):
     for algorithm in benchmarks:
         for benchmark in benchmarks[algorithm]:
             file_name = Path(benchmark).stem
-            out_path = os.path.join(path_1, file_name + "_benchmark.json")
+            out_path = os.path.join(path_new, file_name + "_benchmark.json")
+            if not os.path.exists(out_path):
+                continue
             f = open(out_path)
             data = json.load(f)
             # For each benchmark, the result is the overall CPU-time evolution

--- a/tools/benchmark.py
+++ b/tools/benchmark.py
@@ -61,6 +61,10 @@ def compare_benchmarks(benchmarks, path_new, path_old):
             if sys.platform == "win32":
                 file_name_new += ".exe"
                 file_name_old += ".exe"
+
+            # Compare benchmarks that exist in both directories:
+            # - Fail if a benchmark is missing in the newer directory.
+            # - Ignore if a benchmark is missing in the older directory.
             if not os.path.exists(file_name_new):
                 print("! Benchmark '%s' doesn't exist. Aborting!" % (file_name_new))
                 print("   Running this benchmark requires a build first.")


### PR DESCRIPTION
Currently, the benchmark comparison workflow will fail every time we add a new benchmark, because it can't find it in the older repository.
This PR fixes the issue by only outputing a warning when a benchmark is missing in the older repository.