### PR TITLE
ci: use the ocaml/setup-ocaml github action

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,14 +46,16 @@ jobs:
 
       - name: Setup | System
         run: |
-          sudo apt-get install doxygen python3-sphinx opam libgmp-dev ninja-build nodejs
+          sudo apt-get install doxygen python3-sphinx libgmp-dev ninja-build nodejs
           sudo pip install --upgrade pip
 
-      - name: Setup | OCaml
+      - name: Setup | OCaml | 1/2
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.14.1
+
+      - name: Setup | OCaml | 2/2
         run: |
-          opam init --auto-setup --disable-sandboxing --yes --bare
-          opam switch create 4.14.1 --yes
-          eval $(opam env)
           opam install --yes ocamlfind odoc ctypes zarith cppo dune
 
       - name: Setup | JS
@@ -89,7 +91,7 @@ jobs:
           ./opam.sh
           cd opam
           eval $(opam env)
-          opam install . --yes --assume-depexts
+          opam install . --yes
           dune build @doc --only-packages=hacl-star
           cp -r _build/default/_doc/_html/* ../build/ocaml/main/
 
@@ -106,7 +108,7 @@ jobs:
               ./opam.sh
               cd opam
               eval $(opam env)
-              opam install . --yes --assume-depexts
+              opam install . --yes
               dune build @doc --only-packages=hacl-star
               cp -r _build/default/_doc/_html/* ../build/ocaml/$tag/
               cd ../

--- a/.github/workflows/ocaml.yml
+++ b/.github/workflows/ocaml.yml
@@ -84,15 +84,18 @@ jobs:
 
       - name: Setup Ubuntu
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install ninja-build opam libgmp-dev
+        run: sudo apt-get install ninja-build libgmp-dev
       - name: Setup macOS
         if: matrix.os == 'macos-latest'
-        run: brew install ninja opam gmp pkg-config
-      - name: OCaml Setup
+        run: brew install ninja gmp pkg-config
+
+      - name: OCaml Setup 1/2
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.14.1
+
+      - name: OCaml Setup 2/2
         run: |
-          opam init --auto-setup --disable-sandboxing --yes --bare
-          opam switch create 4.14.1 --yes
-          eval $(opam env)
           opam install --yes ocamlfind ctypes zarith cppo
 
       - name: Setup HACL opam
@@ -100,4 +103,4 @@ jobs:
 
       - name: Package & Test
         working-directory: opam
-        run: opam install . --verbose --with-test --yes --assume-depexts
+        run: opam install . --verbose --with-test --yes


### PR DESCRIPTION
This PR updates the `ocaml` and `gh-pages` workflows to use the [ocaml/setup-ocaml](https://github.com/marketplace/actions/set-up-ocaml) github action.
Doing so should avoid building ocaml on every run and reduce the execution time for these workflows.
Fixes #373 