### PR TITLE
docs: Use `navbar-logo.html` instead of `sidebar-logo.html`.

### DIFF
--- a/docs/reference/conf.py
+++ b/docs/reference/conf.py
@@ -45,7 +45,7 @@ templates_path = ['_templates']
 
 html_sidebars = {
     "**": [
-        "sidebar-logo.html",
+        "navbar-logo.html",
         "book.html",
         "search-field.html",
         "sbt-sidebar-nav.html",


### PR DESCRIPTION
@pnmadelaine reproduced and verified that this fixes the issue in a local docker container with the latest pip version.

Let's give this a try (as it is a good change anyway) but revalidate should we experience another break in the future.