### PR TITLE
OCaml API: update opam file for hacl-star-raw

### DIFF
--- a/ocaml/hacl-star-raw.opam
+++ b/ocaml/hacl-star-raw.opam
@@ -21,13 +21,12 @@ depends: [
   "conf-which" {build}
   "conf-cmake" {build}
 ]
+conflicts: [
+  "ocaml-option-bytecode-only"
+]
 available: [
   arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
   (os = "freebsd" | os-family != "bsd")
-]
-x-ci-accept-failures: [
-  "centos-7" # Default C compiler is too old
-  "oraclelinux-7" # Default C compiler is too old
 ]
 build: [
   [make "-C" "hacl-star-raw" "build-c"]


### PR DESCRIPTION
Updates opam file with changes made during review on [ocaml/opam-repository](https://github.com/ocaml/opam-repository):
- specifies bytecode only not supported (can't build on s390x with OCaml 5) ([discussion](https://github.com/ocaml/opam-repository/pull/23551/commits/994ef5ef725b102032bdda15de72ccf2c47ae392#r1144713439))
- removes outdated CI exceptions ([discussion](https://github.com/ocaml/opam-repository/pull/22596#discussion_r1037381972))