### PR TITLE
OCaml API: small fix and test updates for K-256

### DIFF
--- a/ocaml/hacl-star/Hacl.ml
+++ b/ocaml/hacl-star/Hacl.ml
@@ -599,8 +599,9 @@ module K256 = struct
       assert (C.size signature = size_signature);
         Hacl_K256.hacl_K256_ECDSA_secp256k1_ecdsa_is_signature_normalized (C.ctypes_buf signature)
     let normalize_signature ~signature =
-      if Noalloc.Libsecp256k1.normalize_signature ~signature then
-        Some (Bytes.copy signature)
+      let normalized_signature = C.copy signature in
+      if Noalloc.Libsecp256k1.normalize_signature ~signature:normalized_signature then
+        Some (normalized_signature)
       else
         None
   end

--- a/ocaml/hacl-star/SharedDefs.ml
+++ b/ocaml/hacl-star/SharedDefs.ml
@@ -16,6 +16,7 @@ module type Buffer = sig
   val make : int -> bytes
   val disjoint : bytes -> bytes -> bool
   val sub : bytes -> int -> int -> bytes
+  val copy : bytes -> bytes
   val z_compare : bytes -> Z.t -> int
 end
 (** Abstract representation of buffers *)
@@ -35,6 +36,7 @@ module CBytes : Buffer with type t = Bytes.t and type buf = Bytes.t Ctypes.ocaml
   let make l = Bytes.make l '\x00'
   let disjoint b1 b2 = b1 != b2
   let sub = Bytes.sub
+  let copy = Bytes.copy
   let z_compare b z = Z.compare (Z.of_bits (Bytes.to_string b)) z
 end
 (** Representation of [Bytes.t] buffers *)


### PR DESCRIPTION
This MR contains:
- a fix for `Libsecp256k1.normalize_signature`, which, in addition to returning the normalized signature as an option, was also writing it in-place in the input buffer
- more precise testing for K-256 / libsecp256k1 signatures