### PR TITLE
change tech.cryspen.com to cryspen.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains ready-to-use crypto packages developed by [Cryspen] on 
 In particular, it contains a portable C crypto library that selects optimized implementations for each platform,
 as well as Rust, OCaml, and JavaScript bindings for this library.
 
-Currently, we are in the process of adding more usable APIs, [providing extensive documentation](https://tech.cryspen.com/hacl-packages/), and further optimizing the algorithms.
+Currently, we are in the process of adding more usable APIs, [providing extensive documentation](https://cryspen.com/hacl-packages/), and further optimizing the algorithms.
 
 ## What is HACL\* and why should you use HACL Packages?
 

--- a/docs/book/src/hacl-ocaml/readme.md
+++ b/docs/book/src/hacl-ocaml/readme.md
@@ -23,8 +23,8 @@ See [Changes.md] for changes between the versions.
 [opam v0.6.1]: https://opam.ocaml.org/packages/hacl-star/hacl-star.0.6.1/
 [opam v0.6.2]: https://opam.ocaml.org/packages/hacl-star/hacl-star.0.6.2/
 [opam v0.7.0]: https://opam.ocaml.org/packages/hacl-star/hacl-star.0.7.0/
-[docs v0.5.0]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.5.0/index.html
-[docs v0.6.0]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.6.0/index.html
-[docs v0.6.1]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.6.1/index.html
-[docs v0.6.2]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.6.2/index.html
-[docs v0.7.0]: https://tech.cryspen.com/hacl-packages/ocaml/ocaml-v0.7.0/index.html
+[docs v0.5.0]: https://cryspen.com/hacl-packages/ocaml/ocaml-v0.5.0/index.html
+[docs v0.6.0]: https://cryspen.com/hacl-packages/ocaml/ocaml-v0.6.0/index.html
+[docs v0.6.1]: https://cryspen.com/hacl-packages/ocaml/ocaml-v0.6.1/index.html
+[docs v0.6.2]: https://cryspen.com/hacl-packages/ocaml/ocaml-v0.6.2/index.html
+[docs v0.7.0]: https://cryspen.com/hacl-packages/ocaml/ocaml-v0.7.0/index.html

--- a/docs/reference/_templates/book.html
+++ b/docs/reference/_templates/book.html
@@ -1,1 +1,1 @@
-<a href="https://tech.cryspen.com/hacl-packages/">Go to the HACL Packages book</a>
+<a href="https://cryspen.com/hacl-packages/">Go to the HACL Packages book</a>

--- a/docs/reference/hacl/aead/chacha20poly1305.md
+++ b/docs/reference/hacl/aead/chacha20poly1305.md
@@ -78,5 +78,5 @@ Support for VEC256 is needed. Please see the [HACL Packages book].
 ````
 `````
 
-[hacl packages book]: https://tech.cryspen.com/hacl-packages/algorithms.html
+[hacl packages book]: https://cryspen.com/hacl-packages/algorithms.html
 [rfc 8439]: https://www.rfc-editor.org/rfc/rfc8439.html

--- a/docs/reference/hacl/mac/index.md
+++ b/docs/reference/hacl/mac/index.md
@@ -97,5 +97,5 @@ Support for VEC256 is needed. Please see the [HACL Packages book].
 ```{doxygenfunction} Hacl_HMAC_legacy_compute_sha1
 ```
 
-[hacl packages book]: https://tech.cryspen.com/hacl-packages/algorithms.html
+[hacl packages book]: https://cryspen.com/hacl-packages/algorithms.html
 [rfc 2104]: https://www.ietf.org/rfc/rfc2104.txt

--- a/ocaml/hacl-star-raw.opam
+++ b/ocaml/hacl-star-raw.opam
@@ -11,7 +11,7 @@ which `hacl-star-raw` is a dependency.
 maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
-homepage: "https://tech.cryspen.com/hacl-packages/"
+homepage: "https://cryspen.com/hacl-packages/"
 bug-reports: "https://github.com/cryspen/hacl-packages/issues"
 depends: [
   "ocaml" { >= "4.08.0" }

--- a/ocaml/hacl-star/hacl-star.opam
+++ b/ocaml/hacl-star/hacl-star.opam
@@ -4,13 +4,13 @@ version: "0.7.0"
 synopsis: "OCaml API for EverCrypt/HACL*"
 description: """
 Documentation for this library can be found
-[here](https://tech.cryspen.com/hacl-packages/ocaml/main/index.html).
+[here](https://cryspen.com/hacl-packages/ocaml/main/index.html).
 """
 maintainer: "Victor Dumitrescu <victor.dumitrescu@nomadic-labs.com>"
 authors: [ "Project Everest" ]
 license: "Apache-2.0"
-homepage: "https://tech.cryspen.com/hacl-packages/"
-doc: "https://tech.cryspen.com/hacl-packages/ocaml/main/index.html"
+homepage: "https://cryspen.com/hacl-packages/"
+doc: "https://cryspen.com/hacl-packages/ocaml/main/index.html"
 bug-reports: "https://github.com/cryspen/hacl-packages/issues"
 depends: [
   "ocaml" {>= "4.08.0"}


### PR DESCRIPTION
The domains changed and this should all go to the top level domain now.