### PR TITLE
hacl-wasm npm package: bump version to 1.4.0

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hacl-wasm",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "hacl-wasm",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "Apache-2.0"
     }
   }

--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hacl-wasm",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Javascript bindings for the KaRaMeL-extracted WebAssembly version of the HACL* cryptographic library",
   "main": "api.js",
   "directories": {


### PR DESCRIPTION
Release the npm package in order to restore compatibility with the OCaml `hacl-star` package version 0.7.1