### PR TITLE
ocaml: fix compatibility with ctypes 0.21.0

### DIFF
--- a/ocaml/META
+++ b/ocaml/META
@@ -1,6 +1,6 @@
 name="hacl-star-raw"
 version="0.7.1"
 description="EverCrypt with Ctypes bindings"
-requires="ctypes"
+requires="ctypes ctypes.stubs"
 archive(native)="ocamlevercrypt.cmxa"
 archive(byte)="ocamlevercrypt.cma"


### PR DESCRIPTION
In ctypes < 0.21.0, the ctypes and ctypes.stubs libraries were installed in the same directory, so depending on one would make the other one visible.
ctypes 0.21.0 installs them in different directories so this makes it an error.
hacl-star-raw uses ctypes.stubs so the dependency should be recorded.
