### PR TITLE
CI: fix documentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: Build & Deploy static content to GitHub Pages
 on:
   push:
     branches: ["main"]
-    pull_request:
+  pull_request:
 
   workflow_dispatch:
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    # build on macos until bindgen is fixed
+    runs-on: macos-latest # runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,13 +28,18 @@ jobs:
         with:
           mdbook-version: "latest"
 
-      - name: Setup | Update
-        run: sudo apt-get update
+      # - name: Setup | Update
+      #   run: sudo apt-get update
+
+      # - name: Setup | System
+      #   run: |
+      #     sudo apt-get install doxygen python3-sphinx libgmp-dev ninja-build nodejs
+      #     sudo pip install --upgrade pip
 
       - name: Setup | System
         run: |
-          sudo apt-get install doxygen python3-sphinx libgmp-dev ninja-build nodejs
-          sudo pip install --upgrade pip
+          brew install doxygen python3-sphinx libgmp-dev ninja-build nodejs
+          pip install --upgrade pip
 
       - name: Setup | OCaml | 1/2
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup | System
         run: |
-          brew install doxygen python3-sphinx libgmp-dev ninja-build nodejs
+          brew install doxygen sphinx-doc libgmp-dev ninja-build nodejs
           pip install --upgrade pip
 
       - name: Setup | OCaml | 1/2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,28 +1,14 @@
-name: Deploy static content to GitHub Pages
+name: Build & Deploy static content to GitHub Pages
 
 on:
   push:
     branches: ["main"]
+    pull_request:
 
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -66,9 +52,6 @@ jobs:
         run: |
           cd docs/reference
           pip install -r requirements.txt
-
-      - name: Setup | Pages
-        uses: actions/configure-pages@v2
 
       - name: Build | Book
         run: |
@@ -144,6 +127,25 @@ jobs:
         with:
           path: "build"
 
+  deploy:
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    # Allow one concurrent deployment
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
+    steps:
+      - name: Setup | Pages
+        uses: actions/configure-pages@v2
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     # build on macos until bindgen is fixed
-    runs-on: macos-latest # runs-on: ubuntu-22.04
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,14 +27,6 @@ jobs:
         uses: peaceiris/actions-mdbook@4b5ef36b314c2599664ca107bb8c02412548d79d
         with:
           mdbook-version: "latest"
-
-      # - name: Setup | Update
-      #   run: sudo apt-get update
-
-      # - name: Setup | System
-      #   run: |
-      #     sudo apt-get install doxygen python3-sphinx libgmp-dev ninja-build nodejs
-      #     sudo pip install --upgrade pip
 
       - name: Setup | System
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,7 +20,7 @@ jobs:
         run: git fetch --tags origin
 
       - name: Setup | mdBook | 1/2
-        uses: hecrj/setup-rust-action@8708beccd22540a3f955ae10cc884af27ca81bf5
+        uses: hecrj/setup-rust-action@f344d1a51e8ad6e1c6c51d9cf8d5a6edf4cfd230
 
       - name: Setup | mdBook | 2/2
         uses: peaceiris/actions-mdbook@4b5ef36b314c2599664ca107bb8c02412548d79d

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Setup | System
         run: |
-          brew install doxygen sphinx-doc libgmp-dev ninja-build nodejs
+          brew install doxygen sphinx-doc gmp ninja node
           pip install --upgrade pip
 
       - name: Setup | OCaml | 1/2


### PR DESCRIPTION
This PR tries to fix the GitHub action deploying the documentation.
It currently fails on main, but I am unable to reproduce the error locally.
This PR also enables building the documentation (but not deploying it) on pull requests, to avoid bad surprises when merging in the future.