### PR TITLE
Rename SHA3 Scalar and Simd256 functions

### DIFF
--- a/benchmarks/sha3.cc
+++ b/benchmarks/sha3.cc
@@ -1,10 +1,10 @@
 #include "util.h"
 
 #include "Hacl_Hash_SHA3.h"
-#include "Hacl_SHA3_Scalar.h"
+#include "Hacl_Hash_SHA3_Scalar.h"
 
 #ifdef HACL_CAN_COMPILE_VEC256
-#include "Hacl_SHA3_Vec256.h"
+#include "Hacl_Hash_SHA3_Simd256.h"
 #endif
 
 const bytes input(1000, 0x37);
@@ -59,10 +59,10 @@ Hacl_Sha3_224(benchmark::State& state)
 BENCHMARK(Hacl_Sha3_224)->Setup(DoSetup);
 
 static void
-Hacl_Scalar_Sha3_224(benchmark::State& state)
+Hacl_Sha3_224_Scalar(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Scalar_sha3_224(
+    Hacl_Hash_SHA3_Scalar_sha3_224(
       input.size(), (uint8_t*)input.data(), digest224_0.data());
   }
   if (digest224_0 != expected_digest_sha3_224) {
@@ -71,14 +71,14 @@ Hacl_Scalar_Sha3_224(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Scalar_Sha3_224)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_224_Scalar)->Setup(DoSetup);
 
 #ifdef HACL_CAN_COMPILE_VEC256
 static void
-Hacl_Vec256_Sha3_224(benchmark::State& state)
+Hacl_Sha3_224_Simd256(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Vec256_sha3_224_vec256(input.size(),
+    Hacl_Hash_SHA3_Simd256_sha3_224(input.size(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
@@ -97,7 +97,7 @@ Hacl_Vec256_Sha3_224(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Vec256_Sha3_224)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_224_Simd256)->Setup(DoSetup);
 #endif
 
 #ifndef NO_OPENSSL
@@ -126,10 +126,10 @@ Hacl_Sha3_256(benchmark::State& state)
 BENCHMARK(Hacl_Sha3_256)->Setup(DoSetup);
 
 static void
-Hacl_Scalar_Sha3_256(benchmark::State& state)
+Hacl_Sha3_256_Scalar(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Scalar_sha3_256(
+    Hacl_Hash_SHA3_Scalar_sha3_256(
       input.size(), (uint8_t*)input.data(), digest256_0.data());
   }
   if (digest256_0 != expected_digest_sha3_256) {
@@ -138,14 +138,14 @@ Hacl_Scalar_Sha3_256(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Scalar_Sha3_256)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_256_Scalar)->Setup(DoSetup);
 
 #ifdef HACL_CAN_COMPILE_VEC256
 static void
-Hacl_Vec256_Sha3_256(benchmark::State& state)
+Hacl_Sha3_256_Simd256(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Vec256_sha3_256_vec256(input.size(),
+    Hacl_Hash_SHA3_Simd256_sha3_256(input.size(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
@@ -164,7 +164,7 @@ Hacl_Vec256_Sha3_256(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Vec256_Sha3_256)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_256_Simd256)->Setup(DoSetup);
 #endif
 
 #include "sha3.h"
@@ -220,10 +220,10 @@ Hacl_Sha3_384(benchmark::State& state)
 BENCHMARK(Hacl_Sha3_384)->Setup(DoSetup);
 
 static void
-Hacl_Scalar_Sha3_384(benchmark::State& state)
+Hacl_Sha3_384_Scalar(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Scalar_sha3_384(
+    Hacl_Hash_SHA3_Scalar_sha3_384(
       input.size(), (uint8_t*)input.data(), digest384_0.data());
   }
   if (digest384_0 != expected_digest_sha3_384) {
@@ -232,14 +232,14 @@ Hacl_Scalar_Sha3_384(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Scalar_Sha3_384)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_384_Scalar)->Setup(DoSetup);
 
 #ifdef HACL_CAN_COMPILE_VEC384
 static void
-Hacl_Vec384_Sha3_384(benchmark::State& state)
+Hacl_Sha3_384_Simd256(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Vec256_sha3_384_vec256(input.size(),
+    Hacl_Hash_SHA3_Simd256_sha3_384(input.size(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
@@ -258,7 +258,7 @@ Hacl_Vec384_Sha3_384(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Vec384_Sha3_384)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_384_Simd256)->Setup(DoSetup);
 #endif
 
 #ifndef NO_OPENSSL
@@ -287,10 +287,10 @@ Hacl_Sha3_512(benchmark::State& state)
 BENCHMARK(Hacl_Sha3_512)->Setup(DoSetup);
 
 static void
-Hacl_Scalar_Sha3_512(benchmark::State& state)
+Hacl_Sha3_512_Scalar(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Scalar_sha3_512(
+    Hacl_Hash_SHA3_Scalar_sha3_512(
       input.size(), (uint8_t*)input.data(), digest512_0.data());
   }
   if (digest512_0 != expected_digest_sha3_512) {
@@ -299,14 +299,14 @@ Hacl_Scalar_Sha3_512(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Scalar_Sha3_512)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_512_Scalar)->Setup(DoSetup);
 
 #ifdef HACL_CAN_COMPILE_VEC256
 static void
-Hacl_Vec512_Sha3_512(benchmark::State& state)
+Hacl_Sha3_512_Simd256(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Vec256_sha3_512_vec256(input.size(),
+    Hacl_Hash_SHA3_Simd256_sha3_512(input.size(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
@@ -325,7 +325,7 @@ Hacl_Vec512_Sha3_512(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Vec512_Sha3_512)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_512_Simd256)->Setup(DoSetup);
 #endif
 
 static void
@@ -444,24 +444,24 @@ Hacl_Sha3_shake128(benchmark::State& state)
 BENCHMARK(Hacl_Sha3_shake128)->Setup(DoSetup);
 
 static void
-Hacl_Scalar_Sha3_shake128(benchmark::State& state)
+Hacl_Sha3_shake128_Scalar(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Scalar_shake128_hacl(input.size(),
+    Hacl_Hash_SHA3_Scalar_shake128(input.size(),
                                    (uint8_t*)input.data(),
                                    digest_shake_0.size(),
                                    digest_shake_0.data());
   }
 }
 
-BENCHMARK(Hacl_Scalar_Sha3_shake128)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_shake128_Scalar)->Setup(DoSetup);
 
 #ifdef HACL_CAN_COMPILE_VEC256
 static void
-Hacl_Vec256_Sha3_shake128(benchmark::State& state)
+Hacl_Sha3_shake128_Simd256(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Vec256_shake128_vec256(input.size(),
+    Hacl_Hash_SHA3_Simd256_shake128(input.size(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
@@ -474,7 +474,7 @@ Hacl_Vec256_Sha3_shake128(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Vec256_Sha3_shake128)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_shake128_Simd256)->Setup(DoSetup);
 #endif
 
 static void
@@ -491,24 +491,24 @@ Hacl_Sha3_shake256(benchmark::State& state)
 BENCHMARK(Hacl_Sha3_shake256)->Setup(DoSetup);
 
 static void
-Hacl_Scalar_Sha3_shake256(benchmark::State& state)
+Hacl_Sha3_shake256_Scalar(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Scalar_shake256_hacl(input.size(),
+    Hacl_Hash_SHA3_Scalar_shake256(input.size(),
                                    (uint8_t*)input.data(),
                                    digest_shake_0.size(),
                                    digest_shake_0.data());
   }
 }
 
-BENCHMARK(Hacl_Scalar_Sha3_shake256)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_shake256_Scalar)->Setup(DoSetup);
 
 #ifdef HACL_CAN_COMPILE_VEC256
 static void
-Hacl_Vec256_Sha3_shake256(benchmark::State& state)
+Hacl_Sha3_shake256_Simd256(benchmark::State& state)
 {
   for (auto _ : state) {
-    Hacl_SHA3_Vec256_shake256_vec256(input.size(),
+    Hacl_Hash_SHA3_Simd256_shake256(input.size(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
                                      (uint8_t*)input.data(),
@@ -521,7 +521,7 @@ Hacl_Vec256_Sha3_shake256(benchmark::State& state)
   }
 }
 
-BENCHMARK(Hacl_Vec256_Sha3_shake256)->Setup(DoSetup);
+BENCHMARK(Hacl_Sha3_shake256_Simd256)->Setup(DoSetup);
 #endif
 
 BENCHMARK_MAIN();

--- a/benchmarks/sha3.cc
+++ b/benchmarks/sha3.cc
@@ -3,6 +3,8 @@
 #include "Hacl_Hash_SHA3.h"
 #include "Hacl_Hash_SHA3_Scalar.h"
 
+#include "util.h"
+
 #ifdef HACL_CAN_COMPILE_VEC256
 #include "Hacl_Hash_SHA3_Simd256.h"
 #endif
@@ -77,6 +79,11 @@ BENCHMARK(Hacl_Sha3_224_Scalar)->Setup(DoSetup);
 static void
 Hacl_Sha3_224_Simd256(benchmark::State& state)
 {
+  if (!vec256_support()) {
+    state.SkipWithError("No vec256 support");
+    return;
+  }
+  
   for (auto _ : state) {
     Hacl_Hash_SHA3_Simd256_sha3_224(input.size(),
                                      (uint8_t*)input.data(),
@@ -144,6 +151,11 @@ BENCHMARK(Hacl_Sha3_256_Scalar)->Setup(DoSetup);
 static void
 Hacl_Sha3_256_Simd256(benchmark::State& state)
 {
+  if (!vec256_support()) {
+    state.SkipWithError("No vec256 support");
+    return;
+  }
+  
   for (auto _ : state) {
     Hacl_Hash_SHA3_Simd256_sha3_256(input.size(),
                                      (uint8_t*)input.data(),
@@ -234,10 +246,15 @@ Hacl_Sha3_384_Scalar(benchmark::State& state)
 
 BENCHMARK(Hacl_Sha3_384_Scalar)->Setup(DoSetup);
 
-#ifdef HACL_CAN_COMPILE_VEC384
+#ifdef HACL_CAN_COMPILE_VEC256
 static void
 Hacl_Sha3_384_Simd256(benchmark::State& state)
 {
+  if (!vec256_support()) {
+    state.SkipWithError("No vec256 support");
+    return;
+  }
+  
   for (auto _ : state) {
     Hacl_Hash_SHA3_Simd256_sha3_384(input.size(),
                                      (uint8_t*)input.data(),
@@ -305,6 +322,11 @@ BENCHMARK(Hacl_Sha3_512_Scalar)->Setup(DoSetup);
 static void
 Hacl_Sha3_512_Simd256(benchmark::State& state)
 {
+  if (!vec256_support()) {
+    state.SkipWithError("No vec256 support");
+    return;
+  }
+  
   for (auto _ : state) {
     Hacl_Hash_SHA3_Simd256_sha3_512(input.size(),
                                      (uint8_t*)input.data(),
@@ -460,6 +482,11 @@ BENCHMARK(Hacl_Sha3_shake128_Scalar)->Setup(DoSetup);
 static void
 Hacl_Sha3_shake128_Simd256(benchmark::State& state)
 {
+  if (!vec256_support()) {
+    state.SkipWithError("No vec256 support");
+    return;
+  }
+  
   for (auto _ : state) {
     Hacl_Hash_SHA3_Simd256_shake128(input.size(),
                                      (uint8_t*)input.data(),
@@ -507,6 +534,11 @@ BENCHMARK(Hacl_Sha3_shake256_Scalar)->Setup(DoSetup);
 static void
 Hacl_Sha3_shake256_Simd256(benchmark::State& state)
 {
+  if (!vec256_support()) {
+    state.SkipWithError("No vec256 support");
+    return;
+  }
+  
   for (auto _ : state) {
     Hacl_Hash_SHA3_Simd256_shake256(input.size(),
                                      (uint8_t*)input.data(),

--- a/config/config.json
+++ b/config/config.json
@@ -328,11 +328,11 @@
         ],
         "sha3-mb": [
             {
-                "file": "Hacl_SHA3_Scalar.c",
+                "file": "Hacl_Hash_SHA3_Scalar.c",
                 "features": "std"
             },
             {
-                "file": "Hacl_SHA3_Vec256.c",
+                "file": "Hacl_Hash_SHA3_Simd256.c",
                 "features": "vec256"
             }
         ]

--- a/config/default_config.cmake
+++ b/config/default_config.cmake
@@ -52,7 +52,7 @@ set(SOURCES_std
 	${PROJECT_SOURCE_DIR}/src/EverCrypt_Chacha20Poly1305.c
 	${PROJECT_SOURCE_DIR}/src/EverCrypt_Poly1305.c
 	${PROJECT_SOURCE_DIR}/src/EverCrypt_AEAD.c
-	${PROJECT_SOURCE_DIR}/src/Hacl_SHA3_Scalar.c
+	${PROJECT_SOURCE_DIR}/src/Hacl_Hash_SHA3_Scalar.c
 )
 set(SOURCES_vec256
 	${PROJECT_SOURCE_DIR}/src/Hacl_Hash_Blake2b_Simd256.c
@@ -65,7 +65,7 @@ set(SOURCES_vec256
 	${PROJECT_SOURCE_DIR}/src/Hacl_HPKE_Curve51_CP256_SHA256.c
 	${PROJECT_SOURCE_DIR}/src/Hacl_HPKE_Curve51_CP256_SHA512.c
 	${PROJECT_SOURCE_DIR}/src/Hacl_HPKE_P256_CP256_SHA256.c
-	${PROJECT_SOURCE_DIR}/src/Hacl_SHA3_Vec256.c
+	${PROJECT_SOURCE_DIR}/src/Hacl_Hash_SHA3_Simd256.c
 )
 set(SOURCES_vec128
 	${PROJECT_SOURCE_DIR}/src/Hacl_Hash_Blake2s_Simd128.c
@@ -241,9 +241,9 @@ set(INCLUDES
 	${PROJECT_SOURCE_DIR}/include/EverCrypt_Chacha20Poly1305.h
 	${PROJECT_SOURCE_DIR}/include/EverCrypt_Poly1305.h
 	${PROJECT_SOURCE_DIR}/include/EverCrypt_AEAD.h
-	${PROJECT_SOURCE_DIR}/include/internal/Hacl_SHA3_Scalar.h
-	${PROJECT_SOURCE_DIR}/include/Hacl_SHA3_Scalar.h
-	${PROJECT_SOURCE_DIR}/include/Hacl_SHA3_Vec256.h
+	${PROJECT_SOURCE_DIR}/include/internal/Hacl_Hash_SHA3_Scalar.h
+	${PROJECT_SOURCE_DIR}/include/Hacl_Hash_SHA3_Scalar.h
+	${PROJECT_SOURCE_DIR}/include/Hacl_Hash_SHA3_Simd256.h
 )
 set(PUBLIC_INCLUDES
 	${PROJECT_SOURCE_DIR}/include/Hacl_NaCl.h
@@ -354,8 +354,8 @@ set(PUBLIC_INCLUDES
 	${PROJECT_SOURCE_DIR}/include/EverCrypt_Chacha20Poly1305.h
 	${PROJECT_SOURCE_DIR}/include/EverCrypt_Poly1305.h
 	${PROJECT_SOURCE_DIR}/include/EverCrypt_AEAD.h
-	${PROJECT_SOURCE_DIR}/include/Hacl_SHA3_Scalar.h
-	${PROJECT_SOURCE_DIR}/include/Hacl_SHA3_Vec256.h
+	${PROJECT_SOURCE_DIR}/include/Hacl_Hash_SHA3_Scalar.h
+	${PROJECT_SOURCE_DIR}/include/Hacl_Hash_SHA3_Simd256.h
 )
 set(ALGORITHMS
 	nacl

--- a/include/Hacl_Hash_SHA3_Scalar.h
+++ b/include/Hacl_Hash_SHA3_Scalar.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_SHA3_Scalar_H
-#define __Hacl_SHA3_Scalar_H
+#ifndef __Hacl_Hash_SHA3_Scalar_H
+#define __Hacl_Hash_SHA3_Scalar_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -36,7 +36,7 @@ extern "C" {
 #include "krml/internal/target.h"
 
 void
-Hacl_SHA3_Scalar_shake128_hacl(
+Hacl_Hash_SHA3_Scalar_shake128(
   uint32_t inputByteLen,
   uint8_t *input,
   uint32_t outputByteLen,
@@ -44,24 +44,24 @@ Hacl_SHA3_Scalar_shake128_hacl(
 );
 
 void
-Hacl_SHA3_Scalar_shake256_hacl(
+Hacl_Hash_SHA3_Scalar_shake256(
   uint32_t inputByteLen,
   uint8_t *input,
   uint32_t outputByteLen,
   uint8_t *output
 );
 
-void Hacl_SHA3_Scalar_sha3_224(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
+void Hacl_Hash_SHA3_Scalar_sha3_224(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
 
-void Hacl_SHA3_Scalar_sha3_256(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
+void Hacl_Hash_SHA3_Scalar_sha3_256(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
 
-void Hacl_SHA3_Scalar_sha3_384(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
+void Hacl_Hash_SHA3_Scalar_sha3_384(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
 
-void Hacl_SHA3_Scalar_sha3_512(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
+void Hacl_Hash_SHA3_Scalar_sha3_512(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
 
 #if defined(__cplusplus)
 }
 #endif
 
-#define __Hacl_SHA3_Scalar_H_DEFINED
+#define __Hacl_Hash_SHA3_Scalar_H_DEFINED
 #endif

--- a/include/Hacl_Hash_SHA3_Simd256.h
+++ b/include/Hacl_Hash_SHA3_Simd256.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __Hacl_SHA3_Vec256_H
-#define __Hacl_SHA3_Vec256_H
+#ifndef __Hacl_Hash_SHA3_Simd256_H
+#define __Hacl_Hash_SHA3_Simd256_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -34,8 +34,6 @@ extern "C" {
 #include "krml/internal/types.h"
 #include "krml/lowstar_endianness.h"
 #include "krml/internal/target.h"
-
-typedef void *Hacl_SHA3_Vec256_disjoint4_4;
 
 typedef struct K____uint8_t___uint8_t__s
 {
@@ -59,7 +57,7 @@ typedef struct K____uint8_t___uint8_t____K____uint8_t___uint8_t__s
 K____uint8_t___uint8_t____K____uint8_t___uint8_t_;
 
 void
-Hacl_SHA3_Vec256_shake128_vec256(
+Hacl_Hash_SHA3_Simd256_shake128(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -73,7 +71,7 @@ Hacl_SHA3_Vec256_shake128_vec256(
 );
 
 void
-Hacl_SHA3_Vec256_shake256_vec256(
+Hacl_Hash_SHA3_Simd256_shake256(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -87,7 +85,7 @@ Hacl_SHA3_Vec256_shake256_vec256(
 );
 
 void
-Hacl_SHA3_Vec256_sha3_224_vec256(
+Hacl_Hash_SHA3_Simd256_sha3_224(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -100,7 +98,7 @@ Hacl_SHA3_Vec256_sha3_224_vec256(
 );
 
 void
-Hacl_SHA3_Vec256_sha3_256_vec256(
+Hacl_Hash_SHA3_Simd256_sha3_256(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -113,7 +111,7 @@ Hacl_SHA3_Vec256_sha3_256_vec256(
 );
 
 void
-Hacl_SHA3_Vec256_sha3_384_vec256(
+Hacl_Hash_SHA3_Simd256_sha3_384(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -126,7 +124,7 @@ Hacl_SHA3_Vec256_sha3_384_vec256(
 );
 
 void
-Hacl_SHA3_Vec256_sha3_512_vec256(
+Hacl_Hash_SHA3_Simd256_sha3_512(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -142,5 +140,5 @@ Hacl_SHA3_Vec256_sha3_512_vec256(
 }
 #endif
 
-#define __Hacl_SHA3_Vec256_H_DEFINED
+#define __Hacl_Hash_SHA3_Simd256_H_DEFINED
 #endif

--- a/include/internal/Hacl_Hash_SHA3_Scalar.h
+++ b/include/internal/Hacl_Hash_SHA3_Scalar.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_SHA3_Scalar_H
-#define __internal_Hacl_SHA3_Scalar_H
+#ifndef __internal_Hacl_Hash_SHA3_Scalar_H
+#define __internal_Hacl_Hash_SHA3_Scalar_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -35,7 +35,7 @@ extern "C" {
 #include "krml/lowstar_endianness.h"
 #include "krml/internal/target.h"
 
-#include "../Hacl_SHA3_Scalar.h"
+#include "../Hacl_Hash_SHA3_Scalar.h"
 
 extern const uint32_t Hacl_Impl_SHA3_Vec_keccak_rotc[24U];
 
@@ -47,5 +47,5 @@ extern const uint64_t Hacl_Impl_SHA3_Vec_keccak_rndc[24U];
 }
 #endif
 
-#define __internal_Hacl_SHA3_Scalar_H_DEFINED
+#define __internal_Hacl_Hash_SHA3_Scalar_H_DEFINED
 #endif

--- a/include/msvc/Hacl_Hash_SHA3_Scalar.h
+++ b/include/msvc/Hacl_Hash_SHA3_Scalar.h
@@ -1,0 +1,67 @@
+/* MIT License
+ *
+ * Copyright (c) 2016-2022 INRIA, CMU and Microsoft Corporation
+ * Copyright (c) 2022-2023 HACL* Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifndef __Hacl_Hash_SHA3_Scalar_H
+#define __Hacl_Hash_SHA3_Scalar_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <string.h>
+#include "krml/internal/types.h"
+#include "krml/lowstar_endianness.h"
+#include "krml/internal/target.h"
+
+void
+Hacl_Hash_SHA3_Scalar_shake128(
+  uint32_t inputByteLen,
+  uint8_t *input,
+  uint32_t outputByteLen,
+  uint8_t *output
+);
+
+void
+Hacl_Hash_SHA3_Scalar_shake256(
+  uint32_t inputByteLen,
+  uint8_t *input,
+  uint32_t outputByteLen,
+  uint8_t *output
+);
+
+void Hacl_Hash_SHA3_Scalar_sha3_224(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
+
+void Hacl_Hash_SHA3_Scalar_sha3_256(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
+
+void Hacl_Hash_SHA3_Scalar_sha3_384(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
+
+void Hacl_Hash_SHA3_Scalar_sha3_512(uint32_t inputByteLen, uint8_t *input, uint8_t *output);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#define __Hacl_Hash_SHA3_Scalar_H_DEFINED
+#endif

--- a/include/msvc/Hacl_Hash_SHA3_Simd256.h
+++ b/include/msvc/Hacl_Hash_SHA3_Simd256.h
@@ -1,0 +1,144 @@
+/* MIT License
+ *
+ * Copyright (c) 2016-2022 INRIA, CMU and Microsoft Corporation
+ * Copyright (c) 2022-2023 HACL* Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#ifndef __Hacl_Hash_SHA3_Simd256_H
+#define __Hacl_Hash_SHA3_Simd256_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#include <string.h>
+#include "krml/internal/types.h"
+#include "krml/lowstar_endianness.h"
+#include "krml/internal/target.h"
+
+typedef struct K____uint8_t___uint8_t__s
+{
+  uint8_t *fst;
+  uint8_t *snd;
+}
+K____uint8_t___uint8_t_;
+
+typedef struct K____uint8_t__K____uint8_t___uint8_t__s
+{
+  uint8_t *fst;
+  K____uint8_t___uint8_t_ snd;
+}
+K____uint8_t__K____uint8_t___uint8_t_;
+
+typedef struct K____uint8_t___uint8_t____K____uint8_t___uint8_t__s
+{
+  uint8_t *fst;
+  K____uint8_t__K____uint8_t___uint8_t_ snd;
+}
+K____uint8_t___uint8_t____K____uint8_t___uint8_t_;
+
+void
+Hacl_Hash_SHA3_Simd256_shake128(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint32_t outputByteLen,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+);
+
+void
+Hacl_Hash_SHA3_Simd256_shake256(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint32_t outputByteLen,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+);
+
+void
+Hacl_Hash_SHA3_Simd256_sha3_224(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+);
+
+void
+Hacl_Hash_SHA3_Simd256_sha3_256(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+);
+
+void
+Hacl_Hash_SHA3_Simd256_sha3_384(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+);
+
+void
+Hacl_Hash_SHA3_Simd256_sha3_512(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#define __Hacl_Hash_SHA3_Simd256_H_DEFINED
+#endif

--- a/include/msvc/internal/Hacl_Hash_SHA3_Scalar.h
+++ b/include/msvc/internal/Hacl_Hash_SHA3_Scalar.h
@@ -23,8 +23,8 @@
  */
 
 
-#ifndef __internal_Hacl_SHA3_Scalar_H
-#define __internal_Hacl_SHA3_Scalar_H
+#ifndef __internal_Hacl_Hash_SHA3_Scalar_H
+#define __internal_Hacl_Hash_SHA3_Scalar_H
 
 #if defined(__cplusplus)
 extern "C" {
@@ -35,7 +35,7 @@ extern "C" {
 #include "krml/lowstar_endianness.h"
 #include "krml/internal/target.h"
 
-#include "../Hacl_SHA3_Scalar.h"
+#include "../Hacl_Hash_SHA3_Scalar.h"
 
 extern const uint32_t Hacl_Impl_SHA3_Vec_keccak_rotc[24U];
 
@@ -47,5 +47,5 @@ extern const uint64_t Hacl_Impl_SHA3_Vec_keccak_rndc[24U];
 }
 #endif
 
-#define __internal_Hacl_SHA3_Scalar_H_DEFINED
+#define __internal_Hacl_Hash_SHA3_Scalar_H_DEFINED
 #endif

--- a/src/Hacl_Hash_SHA3_Scalar.c
+++ b/src/Hacl_Hash_SHA3_Scalar.c
@@ -23,7 +23,7 @@
  */
 
 
-#include "internal/Hacl_SHA3_Scalar.h"
+#include "internal/Hacl_Hash_SHA3_Scalar.h"
 
 const
 uint32_t
@@ -54,7 +54,7 @@ Hacl_Impl_SHA3_Vec_keccak_rndc[24U] =
   };
 
 void
-Hacl_SHA3_Scalar_shake128_hacl(
+Hacl_Hash_SHA3_Scalar_shake128(
   uint32_t inputByteLen,
   uint8_t *input,
   uint32_t outputByteLen,
@@ -446,7 +446,7 @@ Hacl_SHA3_Scalar_shake128_hacl(
 }
 
 void
-Hacl_SHA3_Scalar_shake256_hacl(
+Hacl_Hash_SHA3_Scalar_shake256(
   uint32_t inputByteLen,
   uint8_t *input,
   uint32_t outputByteLen,
@@ -837,7 +837,7 @@ Hacl_SHA3_Scalar_shake256_hacl(
   memcpy(output + outputByteLen - remOut, hbuf, remOut * sizeof (uint8_t));
 }
 
-void Hacl_SHA3_Scalar_sha3_224(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
+void Hacl_Hash_SHA3_Scalar_sha3_224(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
 {
   uint32_t rateInBytes = 144U;
   uint64_t s[25U] = { 0U };
@@ -1223,7 +1223,7 @@ void Hacl_SHA3_Scalar_sha3_224(uint32_t inputByteLen, uint8_t *input, uint8_t *o
   memcpy(output + 28U - remOut, hbuf, remOut * sizeof (uint8_t));
 }
 
-void Hacl_SHA3_Scalar_sha3_256(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
+void Hacl_Hash_SHA3_Scalar_sha3_256(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
 {
   uint32_t rateInBytes = 136U;
   uint64_t s[25U] = { 0U };
@@ -1609,7 +1609,7 @@ void Hacl_SHA3_Scalar_sha3_256(uint32_t inputByteLen, uint8_t *input, uint8_t *o
   memcpy(output + 32U - remOut, hbuf, remOut * sizeof (uint8_t));
 }
 
-void Hacl_SHA3_Scalar_sha3_384(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
+void Hacl_Hash_SHA3_Scalar_sha3_384(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
 {
   uint32_t rateInBytes = 104U;
   uint64_t s[25U] = { 0U };
@@ -1995,7 +1995,7 @@ void Hacl_SHA3_Scalar_sha3_384(uint32_t inputByteLen, uint8_t *input, uint8_t *o
   memcpy(output + 48U - remOut, hbuf, remOut * sizeof (uint8_t));
 }
 
-void Hacl_SHA3_Scalar_sha3_512(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
+void Hacl_Hash_SHA3_Scalar_sha3_512(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
 {
   uint32_t rateInBytes = 72U;
   uint64_t s[25U] = { 0U };

--- a/src/Hacl_Hash_SHA3_Simd256.c
+++ b/src/Hacl_Hash_SHA3_Simd256.c
@@ -23,13 +23,13 @@
  */
 
 
-#include "Hacl_SHA3_Vec256.h"
+#include "Hacl_Hash_SHA3_Simd256.h"
 
-#include "internal/Hacl_SHA3_Scalar.h"
+#include "internal/Hacl_Hash_SHA3_Scalar.h"
 #include "libintvector.h"
 
 void
-Hacl_SHA3_Vec256_shake128_vec256(
+Hacl_Hash_SHA3_Simd256_shake128(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -1704,7 +1704,7 @@ Hacl_SHA3_Vec256_shake128_vec256(
 }
 
 void
-Hacl_SHA3_Vec256_shake256_vec256(
+Hacl_Hash_SHA3_Simd256_shake256(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -3379,7 +3379,7 @@ Hacl_SHA3_Vec256_shake256_vec256(
 }
 
 void
-Hacl_SHA3_Vec256_sha3_224_vec256(
+Hacl_Hash_SHA3_Simd256_sha3_224(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -5053,7 +5053,7 @@ Hacl_SHA3_Vec256_sha3_224_vec256(
 }
 
 void
-Hacl_SHA3_Vec256_sha3_256_vec256(
+Hacl_Hash_SHA3_Simd256_sha3_256(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -6727,7 +6727,7 @@ Hacl_SHA3_Vec256_sha3_256_vec256(
 }
 
 void
-Hacl_SHA3_Vec256_sha3_384_vec256(
+Hacl_Hash_SHA3_Simd256_sha3_384(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,
@@ -8401,7 +8401,7 @@ Hacl_SHA3_Vec256_sha3_384_vec256(
 }
 
 void
-Hacl_SHA3_Vec256_sha3_512_vec256(
+Hacl_Hash_SHA3_Simd256_sha3_512(
   uint32_t inputByteLen,
   uint8_t *input0,
   uint8_t *input1,

--- a/src/msvc/Hacl_Hash_SHA3_Scalar.c
+++ b/src/msvc/Hacl_Hash_SHA3_Scalar.c
@@ -1,0 +1,2383 @@
+/* MIT License
+ *
+ * Copyright (c) 2016-2022 INRIA, CMU and Microsoft Corporation
+ * Copyright (c) 2022-2023 HACL* Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include "internal/Hacl_Hash_SHA3_Scalar.h"
+
+const
+uint32_t
+Hacl_Impl_SHA3_Vec_keccak_rotc[24U] =
+  {
+    1U, 3U, 6U, 10U, 15U, 21U, 28U, 36U, 45U, 55U, 2U, 14U, 27U, 41U, 56U, 8U, 25U, 43U, 62U, 18U,
+    39U, 61U, 20U, 44U
+  };
+
+const
+uint32_t
+Hacl_Impl_SHA3_Vec_keccak_piln[24U] =
+  {
+    10U, 7U, 11U, 17U, 18U, 3U, 5U, 16U, 8U, 21U, 24U, 4U, 15U, 23U, 19U, 13U, 12U, 2U, 20U, 14U,
+    22U, 9U, 6U, 1U
+  };
+
+const
+uint64_t
+Hacl_Impl_SHA3_Vec_keccak_rndc[24U] =
+  {
+    0x0000000000000001ULL, 0x0000000000008082ULL, 0x800000000000808aULL, 0x8000000080008000ULL,
+    0x000000000000808bULL, 0x0000000080000001ULL, 0x8000000080008081ULL, 0x8000000000008009ULL,
+    0x000000000000008aULL, 0x0000000000000088ULL, 0x0000000080008009ULL, 0x000000008000000aULL,
+    0x000000008000808bULL, 0x800000000000008bULL, 0x8000000000008089ULL, 0x8000000000008003ULL,
+    0x8000000000008002ULL, 0x8000000000000080ULL, 0x000000000000800aULL, 0x800000008000000aULL,
+    0x8000000080008081ULL, 0x8000000000008080ULL, 0x0000000080000001ULL, 0x8000000080008008ULL
+  };
+
+void
+Hacl_Hash_SHA3_Scalar_shake128(
+  uint32_t inputByteLen,
+  uint8_t *input,
+  uint32_t outputByteLen,
+  uint8_t *output
+)
+{
+  uint32_t rateInBytes = 168U;
+  uint64_t s[25U] = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b1[256U] = { 0U };
+    uint8_t *b_ = b1;
+    uint8_t *b0 = input;
+    uint8_t *bl0 = b_;
+    memcpy(bl0, b0 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    uint64_t ws[32U] = { 0U };
+    uint8_t *b = b_;
+    uint64_t u = load64_le(b);
+    ws[0U] = u;
+    uint64_t u0 = load64_le(b + 8U);
+    ws[1U] = u0;
+    uint64_t u1 = load64_le(b + 16U);
+    ws[2U] = u1;
+    uint64_t u2 = load64_le(b + 24U);
+    ws[3U] = u2;
+    uint64_t u3 = load64_le(b + 32U);
+    ws[4U] = u3;
+    uint64_t u4 = load64_le(b + 40U);
+    ws[5U] = u4;
+    uint64_t u5 = load64_le(b + 48U);
+    ws[6U] = u5;
+    uint64_t u6 = load64_le(b + 56U);
+    ws[7U] = u6;
+    uint64_t u7 = load64_le(b + 64U);
+    ws[8U] = u7;
+    uint64_t u8 = load64_le(b + 72U);
+    ws[9U] = u8;
+    uint64_t u9 = load64_le(b + 80U);
+    ws[10U] = u9;
+    uint64_t u10 = load64_le(b + 88U);
+    ws[11U] = u10;
+    uint64_t u11 = load64_le(b + 96U);
+    ws[12U] = u11;
+    uint64_t u12 = load64_le(b + 104U);
+    ws[13U] = u12;
+    uint64_t u13 = load64_le(b + 112U);
+    ws[14U] = u13;
+    uint64_t u14 = load64_le(b + 120U);
+    ws[15U] = u14;
+    uint64_t u15 = load64_le(b + 128U);
+    ws[16U] = u15;
+    uint64_t u16 = load64_le(b + 136U);
+    ws[17U] = u16;
+    uint64_t u17 = load64_le(b + 144U);
+    ws[18U] = u17;
+    uint64_t u18 = load64_le(b + 152U);
+    ws[19U] = u18;
+    uint64_t u19 = load64_le(b + 160U);
+    ws[20U] = u19;
+    uint64_t u20 = load64_le(b + 168U);
+    ws[21U] = u20;
+    uint64_t u21 = load64_le(b + 176U);
+    ws[22U] = u21;
+    uint64_t u22 = load64_le(b + 184U);
+    ws[23U] = u22;
+    uint64_t u23 = load64_le(b + 192U);
+    ws[24U] = u23;
+    uint64_t u24 = load64_le(b + 200U);
+    ws[25U] = u24;
+    uint64_t u25 = load64_le(b + 208U);
+    ws[26U] = u25;
+    uint64_t u26 = load64_le(b + 216U);
+    ws[27U] = u26;
+    uint64_t u27 = load64_le(b + 224U);
+    ws[28U] = u27;
+    uint64_t u28 = load64_le(b + 232U);
+    ws[29U] = u28;
+    uint64_t u29 = load64_le(b + 240U);
+    ws[30U] = u29;
+    uint64_t u30 = load64_le(b + 248U);
+    ws[31U] = u30;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = s[i] ^ ws[i];
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____0 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____0 << 1U | uu____0 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____1 = current;
+        s[_Y] = uu____1 << r | uu____1 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b2[256U] = { 0U };
+  uint8_t *b_ = b2;
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b00 = input;
+  uint8_t *bl0 = b_;
+  memcpy(bl0, b00 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b01 = b_;
+  b01[rem] = 0x1FU;
+  uint64_t ws0[32U] = { 0U };
+  uint8_t *b = b_;
+  uint64_t u0 = load64_le(b);
+  ws0[0U] = u0;
+  uint64_t u1 = load64_le(b + 8U);
+  ws0[1U] = u1;
+  uint64_t u2 = load64_le(b + 16U);
+  ws0[2U] = u2;
+  uint64_t u3 = load64_le(b + 24U);
+  ws0[3U] = u3;
+  uint64_t u4 = load64_le(b + 32U);
+  ws0[4U] = u4;
+  uint64_t u5 = load64_le(b + 40U);
+  ws0[5U] = u5;
+  uint64_t u6 = load64_le(b + 48U);
+  ws0[6U] = u6;
+  uint64_t u7 = load64_le(b + 56U);
+  ws0[7U] = u7;
+  uint64_t u8 = load64_le(b + 64U);
+  ws0[8U] = u8;
+  uint64_t u9 = load64_le(b + 72U);
+  ws0[9U] = u9;
+  uint64_t u10 = load64_le(b + 80U);
+  ws0[10U] = u10;
+  uint64_t u11 = load64_le(b + 88U);
+  ws0[11U] = u11;
+  uint64_t u12 = load64_le(b + 96U);
+  ws0[12U] = u12;
+  uint64_t u13 = load64_le(b + 104U);
+  ws0[13U] = u13;
+  uint64_t u14 = load64_le(b + 112U);
+  ws0[14U] = u14;
+  uint64_t u15 = load64_le(b + 120U);
+  ws0[15U] = u15;
+  uint64_t u16 = load64_le(b + 128U);
+  ws0[16U] = u16;
+  uint64_t u17 = load64_le(b + 136U);
+  ws0[17U] = u17;
+  uint64_t u18 = load64_le(b + 144U);
+  ws0[18U] = u18;
+  uint64_t u19 = load64_le(b + 152U);
+  ws0[19U] = u19;
+  uint64_t u20 = load64_le(b + 160U);
+  ws0[20U] = u20;
+  uint64_t u21 = load64_le(b + 168U);
+  ws0[21U] = u21;
+  uint64_t u22 = load64_le(b + 176U);
+  ws0[22U] = u22;
+  uint64_t u23 = load64_le(b + 184U);
+  ws0[23U] = u23;
+  uint64_t u24 = load64_le(b + 192U);
+  ws0[24U] = u24;
+  uint64_t u25 = load64_le(b + 200U);
+  ws0[25U] = u25;
+  uint64_t u26 = load64_le(b + 208U);
+  ws0[26U] = u26;
+  uint64_t u27 = load64_le(b + 216U);
+  ws0[27U] = u27;
+  uint64_t u28 = load64_le(b + 224U);
+  ws0[28U] = u28;
+  uint64_t u29 = load64_le(b + 232U);
+  ws0[29U] = u29;
+  uint64_t u30 = load64_le(b + 240U);
+  ws0[30U] = u30;
+  uint64_t u31 = load64_le(b + 248U);
+  ws0[31U] = u31;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws0[i];
+  }
+  uint8_t b3[256U] = { 0U };
+  uint8_t *b4 = b3;
+  uint8_t *b0 = b4;
+  b0[rateInBytes - 1U] = 0x80U;
+  uint64_t ws1[32U] = { 0U };
+  uint8_t *b1 = b4;
+  uint64_t u = load64_le(b1);
+  ws1[0U] = u;
+  uint64_t u32 = load64_le(b1 + 8U);
+  ws1[1U] = u32;
+  uint64_t u33 = load64_le(b1 + 16U);
+  ws1[2U] = u33;
+  uint64_t u34 = load64_le(b1 + 24U);
+  ws1[3U] = u34;
+  uint64_t u35 = load64_le(b1 + 32U);
+  ws1[4U] = u35;
+  uint64_t u36 = load64_le(b1 + 40U);
+  ws1[5U] = u36;
+  uint64_t u37 = load64_le(b1 + 48U);
+  ws1[6U] = u37;
+  uint64_t u38 = load64_le(b1 + 56U);
+  ws1[7U] = u38;
+  uint64_t u39 = load64_le(b1 + 64U);
+  ws1[8U] = u39;
+  uint64_t u40 = load64_le(b1 + 72U);
+  ws1[9U] = u40;
+  uint64_t u41 = load64_le(b1 + 80U);
+  ws1[10U] = u41;
+  uint64_t u42 = load64_le(b1 + 88U);
+  ws1[11U] = u42;
+  uint64_t u43 = load64_le(b1 + 96U);
+  ws1[12U] = u43;
+  uint64_t u44 = load64_le(b1 + 104U);
+  ws1[13U] = u44;
+  uint64_t u45 = load64_le(b1 + 112U);
+  ws1[14U] = u45;
+  uint64_t u46 = load64_le(b1 + 120U);
+  ws1[15U] = u46;
+  uint64_t u47 = load64_le(b1 + 128U);
+  ws1[16U] = u47;
+  uint64_t u48 = load64_le(b1 + 136U);
+  ws1[17U] = u48;
+  uint64_t u49 = load64_le(b1 + 144U);
+  ws1[18U] = u49;
+  uint64_t u50 = load64_le(b1 + 152U);
+  ws1[19U] = u50;
+  uint64_t u51 = load64_le(b1 + 160U);
+  ws1[20U] = u51;
+  uint64_t u52 = load64_le(b1 + 168U);
+  ws1[21U] = u52;
+  uint64_t u53 = load64_le(b1 + 176U);
+  ws1[22U] = u53;
+  uint64_t u54 = load64_le(b1 + 184U);
+  ws1[23U] = u54;
+  uint64_t u55 = load64_le(b1 + 192U);
+  ws1[24U] = u55;
+  uint64_t u56 = load64_le(b1 + 200U);
+  ws1[25U] = u56;
+  uint64_t u57 = load64_le(b1 + 208U);
+  ws1[26U] = u57;
+  uint64_t u58 = load64_le(b1 + 216U);
+  ws1[27U] = u58;
+  uint64_t u59 = load64_le(b1 + 224U);
+  ws1[28U] = u59;
+  uint64_t u60 = load64_le(b1 + 232U);
+  ws1[29U] = u60;
+  uint64_t u61 = load64_le(b1 + 240U);
+  ws1[30U] = u61;
+  uint64_t u62 = load64_le(b1 + 248U);
+  ws1[31U] = u62;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws1[i];
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    uint64_t _C[5U] = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      uint64_t uu____2 = _C[(i1 + 1U) % 5U];
+      uint64_t _D = _C[(i1 + 4U) % 5U] ^ (uu____2 << 1U | uu____2 >> 63U);
+      KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i1 + 5U * i] = s[i1 + 5U * i] ^ _D;););
+    uint64_t x = s[1U];
+    uint64_t current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      uint64_t temp = s[_Y];
+      uint64_t uu____3 = current;
+      s[_Y] = uu____3 << r | uu____3 >> (64U - r);
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+      uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+      uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+      uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+      uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    s[0U] = s[0U] ^ c;
+  }
+  for (uint32_t i0 = 0U; i0 < outputByteLen / rateInBytes; i0++)
+  {
+    uint8_t hbuf[256U] = { 0U };
+    uint64_t ws[32U] = { 0U };
+    memcpy(ws, s, 25U * sizeof (uint64_t));
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      store64_le(hbuf + i * 8U, ws[i]);
+    }
+    memcpy(output + i0 * rateInBytes, hbuf, rateInBytes * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____4 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____4 << 1U | uu____4 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____5 = current;
+        s[_Y] = uu____5 << r | uu____5 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t remOut = outputByteLen % rateInBytes;
+  uint8_t hbuf[256U] = { 0U };
+  uint64_t ws[32U] = { 0U };
+  memcpy(ws, s, 25U * sizeof (uint64_t));
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    store64_le(hbuf + i * 8U, ws[i]);
+  }
+  memcpy(output + outputByteLen - remOut, hbuf, remOut * sizeof (uint8_t));
+}
+
+void
+Hacl_Hash_SHA3_Scalar_shake256(
+  uint32_t inputByteLen,
+  uint8_t *input,
+  uint32_t outputByteLen,
+  uint8_t *output
+)
+{
+  uint32_t rateInBytes = 136U;
+  uint64_t s[25U] = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b1[256U] = { 0U };
+    uint8_t *b_ = b1;
+    uint8_t *b0 = input;
+    uint8_t *bl0 = b_;
+    memcpy(bl0, b0 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    uint64_t ws[32U] = { 0U };
+    uint8_t *b = b_;
+    uint64_t u = load64_le(b);
+    ws[0U] = u;
+    uint64_t u0 = load64_le(b + 8U);
+    ws[1U] = u0;
+    uint64_t u1 = load64_le(b + 16U);
+    ws[2U] = u1;
+    uint64_t u2 = load64_le(b + 24U);
+    ws[3U] = u2;
+    uint64_t u3 = load64_le(b + 32U);
+    ws[4U] = u3;
+    uint64_t u4 = load64_le(b + 40U);
+    ws[5U] = u4;
+    uint64_t u5 = load64_le(b + 48U);
+    ws[6U] = u5;
+    uint64_t u6 = load64_le(b + 56U);
+    ws[7U] = u6;
+    uint64_t u7 = load64_le(b + 64U);
+    ws[8U] = u7;
+    uint64_t u8 = load64_le(b + 72U);
+    ws[9U] = u8;
+    uint64_t u9 = load64_le(b + 80U);
+    ws[10U] = u9;
+    uint64_t u10 = load64_le(b + 88U);
+    ws[11U] = u10;
+    uint64_t u11 = load64_le(b + 96U);
+    ws[12U] = u11;
+    uint64_t u12 = load64_le(b + 104U);
+    ws[13U] = u12;
+    uint64_t u13 = load64_le(b + 112U);
+    ws[14U] = u13;
+    uint64_t u14 = load64_le(b + 120U);
+    ws[15U] = u14;
+    uint64_t u15 = load64_le(b + 128U);
+    ws[16U] = u15;
+    uint64_t u16 = load64_le(b + 136U);
+    ws[17U] = u16;
+    uint64_t u17 = load64_le(b + 144U);
+    ws[18U] = u17;
+    uint64_t u18 = load64_le(b + 152U);
+    ws[19U] = u18;
+    uint64_t u19 = load64_le(b + 160U);
+    ws[20U] = u19;
+    uint64_t u20 = load64_le(b + 168U);
+    ws[21U] = u20;
+    uint64_t u21 = load64_le(b + 176U);
+    ws[22U] = u21;
+    uint64_t u22 = load64_le(b + 184U);
+    ws[23U] = u22;
+    uint64_t u23 = load64_le(b + 192U);
+    ws[24U] = u23;
+    uint64_t u24 = load64_le(b + 200U);
+    ws[25U] = u24;
+    uint64_t u25 = load64_le(b + 208U);
+    ws[26U] = u25;
+    uint64_t u26 = load64_le(b + 216U);
+    ws[27U] = u26;
+    uint64_t u27 = load64_le(b + 224U);
+    ws[28U] = u27;
+    uint64_t u28 = load64_le(b + 232U);
+    ws[29U] = u28;
+    uint64_t u29 = load64_le(b + 240U);
+    ws[30U] = u29;
+    uint64_t u30 = load64_le(b + 248U);
+    ws[31U] = u30;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = s[i] ^ ws[i];
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____0 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____0 << 1U | uu____0 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____1 = current;
+        s[_Y] = uu____1 << r | uu____1 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b2[256U] = { 0U };
+  uint8_t *b_ = b2;
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b00 = input;
+  uint8_t *bl0 = b_;
+  memcpy(bl0, b00 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b01 = b_;
+  b01[rem] = 0x1FU;
+  uint64_t ws0[32U] = { 0U };
+  uint8_t *b = b_;
+  uint64_t u0 = load64_le(b);
+  ws0[0U] = u0;
+  uint64_t u1 = load64_le(b + 8U);
+  ws0[1U] = u1;
+  uint64_t u2 = load64_le(b + 16U);
+  ws0[2U] = u2;
+  uint64_t u3 = load64_le(b + 24U);
+  ws0[3U] = u3;
+  uint64_t u4 = load64_le(b + 32U);
+  ws0[4U] = u4;
+  uint64_t u5 = load64_le(b + 40U);
+  ws0[5U] = u5;
+  uint64_t u6 = load64_le(b + 48U);
+  ws0[6U] = u6;
+  uint64_t u7 = load64_le(b + 56U);
+  ws0[7U] = u7;
+  uint64_t u8 = load64_le(b + 64U);
+  ws0[8U] = u8;
+  uint64_t u9 = load64_le(b + 72U);
+  ws0[9U] = u9;
+  uint64_t u10 = load64_le(b + 80U);
+  ws0[10U] = u10;
+  uint64_t u11 = load64_le(b + 88U);
+  ws0[11U] = u11;
+  uint64_t u12 = load64_le(b + 96U);
+  ws0[12U] = u12;
+  uint64_t u13 = load64_le(b + 104U);
+  ws0[13U] = u13;
+  uint64_t u14 = load64_le(b + 112U);
+  ws0[14U] = u14;
+  uint64_t u15 = load64_le(b + 120U);
+  ws0[15U] = u15;
+  uint64_t u16 = load64_le(b + 128U);
+  ws0[16U] = u16;
+  uint64_t u17 = load64_le(b + 136U);
+  ws0[17U] = u17;
+  uint64_t u18 = load64_le(b + 144U);
+  ws0[18U] = u18;
+  uint64_t u19 = load64_le(b + 152U);
+  ws0[19U] = u19;
+  uint64_t u20 = load64_le(b + 160U);
+  ws0[20U] = u20;
+  uint64_t u21 = load64_le(b + 168U);
+  ws0[21U] = u21;
+  uint64_t u22 = load64_le(b + 176U);
+  ws0[22U] = u22;
+  uint64_t u23 = load64_le(b + 184U);
+  ws0[23U] = u23;
+  uint64_t u24 = load64_le(b + 192U);
+  ws0[24U] = u24;
+  uint64_t u25 = load64_le(b + 200U);
+  ws0[25U] = u25;
+  uint64_t u26 = load64_le(b + 208U);
+  ws0[26U] = u26;
+  uint64_t u27 = load64_le(b + 216U);
+  ws0[27U] = u27;
+  uint64_t u28 = load64_le(b + 224U);
+  ws0[28U] = u28;
+  uint64_t u29 = load64_le(b + 232U);
+  ws0[29U] = u29;
+  uint64_t u30 = load64_le(b + 240U);
+  ws0[30U] = u30;
+  uint64_t u31 = load64_le(b + 248U);
+  ws0[31U] = u31;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws0[i];
+  }
+  uint8_t b3[256U] = { 0U };
+  uint8_t *b4 = b3;
+  uint8_t *b0 = b4;
+  b0[rateInBytes - 1U] = 0x80U;
+  uint64_t ws1[32U] = { 0U };
+  uint8_t *b1 = b4;
+  uint64_t u = load64_le(b1);
+  ws1[0U] = u;
+  uint64_t u32 = load64_le(b1 + 8U);
+  ws1[1U] = u32;
+  uint64_t u33 = load64_le(b1 + 16U);
+  ws1[2U] = u33;
+  uint64_t u34 = load64_le(b1 + 24U);
+  ws1[3U] = u34;
+  uint64_t u35 = load64_le(b1 + 32U);
+  ws1[4U] = u35;
+  uint64_t u36 = load64_le(b1 + 40U);
+  ws1[5U] = u36;
+  uint64_t u37 = load64_le(b1 + 48U);
+  ws1[6U] = u37;
+  uint64_t u38 = load64_le(b1 + 56U);
+  ws1[7U] = u38;
+  uint64_t u39 = load64_le(b1 + 64U);
+  ws1[8U] = u39;
+  uint64_t u40 = load64_le(b1 + 72U);
+  ws1[9U] = u40;
+  uint64_t u41 = load64_le(b1 + 80U);
+  ws1[10U] = u41;
+  uint64_t u42 = load64_le(b1 + 88U);
+  ws1[11U] = u42;
+  uint64_t u43 = load64_le(b1 + 96U);
+  ws1[12U] = u43;
+  uint64_t u44 = load64_le(b1 + 104U);
+  ws1[13U] = u44;
+  uint64_t u45 = load64_le(b1 + 112U);
+  ws1[14U] = u45;
+  uint64_t u46 = load64_le(b1 + 120U);
+  ws1[15U] = u46;
+  uint64_t u47 = load64_le(b1 + 128U);
+  ws1[16U] = u47;
+  uint64_t u48 = load64_le(b1 + 136U);
+  ws1[17U] = u48;
+  uint64_t u49 = load64_le(b1 + 144U);
+  ws1[18U] = u49;
+  uint64_t u50 = load64_le(b1 + 152U);
+  ws1[19U] = u50;
+  uint64_t u51 = load64_le(b1 + 160U);
+  ws1[20U] = u51;
+  uint64_t u52 = load64_le(b1 + 168U);
+  ws1[21U] = u52;
+  uint64_t u53 = load64_le(b1 + 176U);
+  ws1[22U] = u53;
+  uint64_t u54 = load64_le(b1 + 184U);
+  ws1[23U] = u54;
+  uint64_t u55 = load64_le(b1 + 192U);
+  ws1[24U] = u55;
+  uint64_t u56 = load64_le(b1 + 200U);
+  ws1[25U] = u56;
+  uint64_t u57 = load64_le(b1 + 208U);
+  ws1[26U] = u57;
+  uint64_t u58 = load64_le(b1 + 216U);
+  ws1[27U] = u58;
+  uint64_t u59 = load64_le(b1 + 224U);
+  ws1[28U] = u59;
+  uint64_t u60 = load64_le(b1 + 232U);
+  ws1[29U] = u60;
+  uint64_t u61 = load64_le(b1 + 240U);
+  ws1[30U] = u61;
+  uint64_t u62 = load64_le(b1 + 248U);
+  ws1[31U] = u62;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws1[i];
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    uint64_t _C[5U] = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      uint64_t uu____2 = _C[(i1 + 1U) % 5U];
+      uint64_t _D = _C[(i1 + 4U) % 5U] ^ (uu____2 << 1U | uu____2 >> 63U);
+      KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i1 + 5U * i] = s[i1 + 5U * i] ^ _D;););
+    uint64_t x = s[1U];
+    uint64_t current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      uint64_t temp = s[_Y];
+      uint64_t uu____3 = current;
+      s[_Y] = uu____3 << r | uu____3 >> (64U - r);
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+      uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+      uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+      uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+      uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    s[0U] = s[0U] ^ c;
+  }
+  for (uint32_t i0 = 0U; i0 < outputByteLen / rateInBytes; i0++)
+  {
+    uint8_t hbuf[256U] = { 0U };
+    uint64_t ws[32U] = { 0U };
+    memcpy(ws, s, 25U * sizeof (uint64_t));
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      store64_le(hbuf + i * 8U, ws[i]);
+    }
+    memcpy(output + i0 * rateInBytes, hbuf, rateInBytes * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____4 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____4 << 1U | uu____4 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____5 = current;
+        s[_Y] = uu____5 << r | uu____5 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t remOut = outputByteLen % rateInBytes;
+  uint8_t hbuf[256U] = { 0U };
+  uint64_t ws[32U] = { 0U };
+  memcpy(ws, s, 25U * sizeof (uint64_t));
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    store64_le(hbuf + i * 8U, ws[i]);
+  }
+  memcpy(output + outputByteLen - remOut, hbuf, remOut * sizeof (uint8_t));
+}
+
+void Hacl_Hash_SHA3_Scalar_sha3_224(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
+{
+  uint32_t rateInBytes = 144U;
+  uint64_t s[25U] = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b1[256U] = { 0U };
+    uint8_t *b_ = b1;
+    uint8_t *b0 = input;
+    uint8_t *bl0 = b_;
+    memcpy(bl0, b0 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    uint64_t ws[32U] = { 0U };
+    uint8_t *b = b_;
+    uint64_t u = load64_le(b);
+    ws[0U] = u;
+    uint64_t u0 = load64_le(b + 8U);
+    ws[1U] = u0;
+    uint64_t u1 = load64_le(b + 16U);
+    ws[2U] = u1;
+    uint64_t u2 = load64_le(b + 24U);
+    ws[3U] = u2;
+    uint64_t u3 = load64_le(b + 32U);
+    ws[4U] = u3;
+    uint64_t u4 = load64_le(b + 40U);
+    ws[5U] = u4;
+    uint64_t u5 = load64_le(b + 48U);
+    ws[6U] = u5;
+    uint64_t u6 = load64_le(b + 56U);
+    ws[7U] = u6;
+    uint64_t u7 = load64_le(b + 64U);
+    ws[8U] = u7;
+    uint64_t u8 = load64_le(b + 72U);
+    ws[9U] = u8;
+    uint64_t u9 = load64_le(b + 80U);
+    ws[10U] = u9;
+    uint64_t u10 = load64_le(b + 88U);
+    ws[11U] = u10;
+    uint64_t u11 = load64_le(b + 96U);
+    ws[12U] = u11;
+    uint64_t u12 = load64_le(b + 104U);
+    ws[13U] = u12;
+    uint64_t u13 = load64_le(b + 112U);
+    ws[14U] = u13;
+    uint64_t u14 = load64_le(b + 120U);
+    ws[15U] = u14;
+    uint64_t u15 = load64_le(b + 128U);
+    ws[16U] = u15;
+    uint64_t u16 = load64_le(b + 136U);
+    ws[17U] = u16;
+    uint64_t u17 = load64_le(b + 144U);
+    ws[18U] = u17;
+    uint64_t u18 = load64_le(b + 152U);
+    ws[19U] = u18;
+    uint64_t u19 = load64_le(b + 160U);
+    ws[20U] = u19;
+    uint64_t u20 = load64_le(b + 168U);
+    ws[21U] = u20;
+    uint64_t u21 = load64_le(b + 176U);
+    ws[22U] = u21;
+    uint64_t u22 = load64_le(b + 184U);
+    ws[23U] = u22;
+    uint64_t u23 = load64_le(b + 192U);
+    ws[24U] = u23;
+    uint64_t u24 = load64_le(b + 200U);
+    ws[25U] = u24;
+    uint64_t u25 = load64_le(b + 208U);
+    ws[26U] = u25;
+    uint64_t u26 = load64_le(b + 216U);
+    ws[27U] = u26;
+    uint64_t u27 = load64_le(b + 224U);
+    ws[28U] = u27;
+    uint64_t u28 = load64_le(b + 232U);
+    ws[29U] = u28;
+    uint64_t u29 = load64_le(b + 240U);
+    ws[30U] = u29;
+    uint64_t u30 = load64_le(b + 248U);
+    ws[31U] = u30;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = s[i] ^ ws[i];
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____0 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____0 << 1U | uu____0 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____1 = current;
+        s[_Y] = uu____1 << r | uu____1 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b2[256U] = { 0U };
+  uint8_t *b_ = b2;
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b00 = input;
+  uint8_t *bl0 = b_;
+  memcpy(bl0, b00 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b01 = b_;
+  b01[rem] = 0x06U;
+  uint64_t ws0[32U] = { 0U };
+  uint8_t *b = b_;
+  uint64_t u0 = load64_le(b);
+  ws0[0U] = u0;
+  uint64_t u1 = load64_le(b + 8U);
+  ws0[1U] = u1;
+  uint64_t u2 = load64_le(b + 16U);
+  ws0[2U] = u2;
+  uint64_t u3 = load64_le(b + 24U);
+  ws0[3U] = u3;
+  uint64_t u4 = load64_le(b + 32U);
+  ws0[4U] = u4;
+  uint64_t u5 = load64_le(b + 40U);
+  ws0[5U] = u5;
+  uint64_t u6 = load64_le(b + 48U);
+  ws0[6U] = u6;
+  uint64_t u7 = load64_le(b + 56U);
+  ws0[7U] = u7;
+  uint64_t u8 = load64_le(b + 64U);
+  ws0[8U] = u8;
+  uint64_t u9 = load64_le(b + 72U);
+  ws0[9U] = u9;
+  uint64_t u10 = load64_le(b + 80U);
+  ws0[10U] = u10;
+  uint64_t u11 = load64_le(b + 88U);
+  ws0[11U] = u11;
+  uint64_t u12 = load64_le(b + 96U);
+  ws0[12U] = u12;
+  uint64_t u13 = load64_le(b + 104U);
+  ws0[13U] = u13;
+  uint64_t u14 = load64_le(b + 112U);
+  ws0[14U] = u14;
+  uint64_t u15 = load64_le(b + 120U);
+  ws0[15U] = u15;
+  uint64_t u16 = load64_le(b + 128U);
+  ws0[16U] = u16;
+  uint64_t u17 = load64_le(b + 136U);
+  ws0[17U] = u17;
+  uint64_t u18 = load64_le(b + 144U);
+  ws0[18U] = u18;
+  uint64_t u19 = load64_le(b + 152U);
+  ws0[19U] = u19;
+  uint64_t u20 = load64_le(b + 160U);
+  ws0[20U] = u20;
+  uint64_t u21 = load64_le(b + 168U);
+  ws0[21U] = u21;
+  uint64_t u22 = load64_le(b + 176U);
+  ws0[22U] = u22;
+  uint64_t u23 = load64_le(b + 184U);
+  ws0[23U] = u23;
+  uint64_t u24 = load64_le(b + 192U);
+  ws0[24U] = u24;
+  uint64_t u25 = load64_le(b + 200U);
+  ws0[25U] = u25;
+  uint64_t u26 = load64_le(b + 208U);
+  ws0[26U] = u26;
+  uint64_t u27 = load64_le(b + 216U);
+  ws0[27U] = u27;
+  uint64_t u28 = load64_le(b + 224U);
+  ws0[28U] = u28;
+  uint64_t u29 = load64_le(b + 232U);
+  ws0[29U] = u29;
+  uint64_t u30 = load64_le(b + 240U);
+  ws0[30U] = u30;
+  uint64_t u31 = load64_le(b + 248U);
+  ws0[31U] = u31;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws0[i];
+  }
+  uint8_t b3[256U] = { 0U };
+  uint8_t *b4 = b3;
+  uint8_t *b0 = b4;
+  b0[rateInBytes - 1U] = 0x80U;
+  uint64_t ws1[32U] = { 0U };
+  uint8_t *b1 = b4;
+  uint64_t u = load64_le(b1);
+  ws1[0U] = u;
+  uint64_t u32 = load64_le(b1 + 8U);
+  ws1[1U] = u32;
+  uint64_t u33 = load64_le(b1 + 16U);
+  ws1[2U] = u33;
+  uint64_t u34 = load64_le(b1 + 24U);
+  ws1[3U] = u34;
+  uint64_t u35 = load64_le(b1 + 32U);
+  ws1[4U] = u35;
+  uint64_t u36 = load64_le(b1 + 40U);
+  ws1[5U] = u36;
+  uint64_t u37 = load64_le(b1 + 48U);
+  ws1[6U] = u37;
+  uint64_t u38 = load64_le(b1 + 56U);
+  ws1[7U] = u38;
+  uint64_t u39 = load64_le(b1 + 64U);
+  ws1[8U] = u39;
+  uint64_t u40 = load64_le(b1 + 72U);
+  ws1[9U] = u40;
+  uint64_t u41 = load64_le(b1 + 80U);
+  ws1[10U] = u41;
+  uint64_t u42 = load64_le(b1 + 88U);
+  ws1[11U] = u42;
+  uint64_t u43 = load64_le(b1 + 96U);
+  ws1[12U] = u43;
+  uint64_t u44 = load64_le(b1 + 104U);
+  ws1[13U] = u44;
+  uint64_t u45 = load64_le(b1 + 112U);
+  ws1[14U] = u45;
+  uint64_t u46 = load64_le(b1 + 120U);
+  ws1[15U] = u46;
+  uint64_t u47 = load64_le(b1 + 128U);
+  ws1[16U] = u47;
+  uint64_t u48 = load64_le(b1 + 136U);
+  ws1[17U] = u48;
+  uint64_t u49 = load64_le(b1 + 144U);
+  ws1[18U] = u49;
+  uint64_t u50 = load64_le(b1 + 152U);
+  ws1[19U] = u50;
+  uint64_t u51 = load64_le(b1 + 160U);
+  ws1[20U] = u51;
+  uint64_t u52 = load64_le(b1 + 168U);
+  ws1[21U] = u52;
+  uint64_t u53 = load64_le(b1 + 176U);
+  ws1[22U] = u53;
+  uint64_t u54 = load64_le(b1 + 184U);
+  ws1[23U] = u54;
+  uint64_t u55 = load64_le(b1 + 192U);
+  ws1[24U] = u55;
+  uint64_t u56 = load64_le(b1 + 200U);
+  ws1[25U] = u56;
+  uint64_t u57 = load64_le(b1 + 208U);
+  ws1[26U] = u57;
+  uint64_t u58 = load64_le(b1 + 216U);
+  ws1[27U] = u58;
+  uint64_t u59 = load64_le(b1 + 224U);
+  ws1[28U] = u59;
+  uint64_t u60 = load64_le(b1 + 232U);
+  ws1[29U] = u60;
+  uint64_t u61 = load64_le(b1 + 240U);
+  ws1[30U] = u61;
+  uint64_t u62 = load64_le(b1 + 248U);
+  ws1[31U] = u62;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws1[i];
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    uint64_t _C[5U] = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      uint64_t uu____2 = _C[(i1 + 1U) % 5U];
+      uint64_t _D = _C[(i1 + 4U) % 5U] ^ (uu____2 << 1U | uu____2 >> 63U);
+      KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i1 + 5U * i] = s[i1 + 5U * i] ^ _D;););
+    uint64_t x = s[1U];
+    uint64_t current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      uint64_t temp = s[_Y];
+      uint64_t uu____3 = current;
+      s[_Y] = uu____3 << r | uu____3 >> (64U - r);
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+      uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+      uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+      uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+      uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    s[0U] = s[0U] ^ c;
+  }
+  for (uint32_t i0 = 0U; i0 < 28U / rateInBytes; i0++)
+  {
+    uint8_t hbuf[256U] = { 0U };
+    uint64_t ws[32U] = { 0U };
+    memcpy(ws, s, 25U * sizeof (uint64_t));
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      store64_le(hbuf + i * 8U, ws[i]);
+    }
+    memcpy(output + i0 * rateInBytes, hbuf, rateInBytes * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____4 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____4 << 1U | uu____4 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____5 = current;
+        s[_Y] = uu____5 << r | uu____5 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t remOut = 28U % rateInBytes;
+  uint8_t hbuf[256U] = { 0U };
+  uint64_t ws[32U] = { 0U };
+  memcpy(ws, s, 25U * sizeof (uint64_t));
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    store64_le(hbuf + i * 8U, ws[i]);
+  }
+  memcpy(output + 28U - remOut, hbuf, remOut * sizeof (uint8_t));
+}
+
+void Hacl_Hash_SHA3_Scalar_sha3_256(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
+{
+  uint32_t rateInBytes = 136U;
+  uint64_t s[25U] = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b1[256U] = { 0U };
+    uint8_t *b_ = b1;
+    uint8_t *b0 = input;
+    uint8_t *bl0 = b_;
+    memcpy(bl0, b0 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    uint64_t ws[32U] = { 0U };
+    uint8_t *b = b_;
+    uint64_t u = load64_le(b);
+    ws[0U] = u;
+    uint64_t u0 = load64_le(b + 8U);
+    ws[1U] = u0;
+    uint64_t u1 = load64_le(b + 16U);
+    ws[2U] = u1;
+    uint64_t u2 = load64_le(b + 24U);
+    ws[3U] = u2;
+    uint64_t u3 = load64_le(b + 32U);
+    ws[4U] = u3;
+    uint64_t u4 = load64_le(b + 40U);
+    ws[5U] = u4;
+    uint64_t u5 = load64_le(b + 48U);
+    ws[6U] = u5;
+    uint64_t u6 = load64_le(b + 56U);
+    ws[7U] = u6;
+    uint64_t u7 = load64_le(b + 64U);
+    ws[8U] = u7;
+    uint64_t u8 = load64_le(b + 72U);
+    ws[9U] = u8;
+    uint64_t u9 = load64_le(b + 80U);
+    ws[10U] = u9;
+    uint64_t u10 = load64_le(b + 88U);
+    ws[11U] = u10;
+    uint64_t u11 = load64_le(b + 96U);
+    ws[12U] = u11;
+    uint64_t u12 = load64_le(b + 104U);
+    ws[13U] = u12;
+    uint64_t u13 = load64_le(b + 112U);
+    ws[14U] = u13;
+    uint64_t u14 = load64_le(b + 120U);
+    ws[15U] = u14;
+    uint64_t u15 = load64_le(b + 128U);
+    ws[16U] = u15;
+    uint64_t u16 = load64_le(b + 136U);
+    ws[17U] = u16;
+    uint64_t u17 = load64_le(b + 144U);
+    ws[18U] = u17;
+    uint64_t u18 = load64_le(b + 152U);
+    ws[19U] = u18;
+    uint64_t u19 = load64_le(b + 160U);
+    ws[20U] = u19;
+    uint64_t u20 = load64_le(b + 168U);
+    ws[21U] = u20;
+    uint64_t u21 = load64_le(b + 176U);
+    ws[22U] = u21;
+    uint64_t u22 = load64_le(b + 184U);
+    ws[23U] = u22;
+    uint64_t u23 = load64_le(b + 192U);
+    ws[24U] = u23;
+    uint64_t u24 = load64_le(b + 200U);
+    ws[25U] = u24;
+    uint64_t u25 = load64_le(b + 208U);
+    ws[26U] = u25;
+    uint64_t u26 = load64_le(b + 216U);
+    ws[27U] = u26;
+    uint64_t u27 = load64_le(b + 224U);
+    ws[28U] = u27;
+    uint64_t u28 = load64_le(b + 232U);
+    ws[29U] = u28;
+    uint64_t u29 = load64_le(b + 240U);
+    ws[30U] = u29;
+    uint64_t u30 = load64_le(b + 248U);
+    ws[31U] = u30;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = s[i] ^ ws[i];
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____0 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____0 << 1U | uu____0 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____1 = current;
+        s[_Y] = uu____1 << r | uu____1 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b2[256U] = { 0U };
+  uint8_t *b_ = b2;
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b00 = input;
+  uint8_t *bl0 = b_;
+  memcpy(bl0, b00 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b01 = b_;
+  b01[rem] = 0x06U;
+  uint64_t ws0[32U] = { 0U };
+  uint8_t *b = b_;
+  uint64_t u0 = load64_le(b);
+  ws0[0U] = u0;
+  uint64_t u1 = load64_le(b + 8U);
+  ws0[1U] = u1;
+  uint64_t u2 = load64_le(b + 16U);
+  ws0[2U] = u2;
+  uint64_t u3 = load64_le(b + 24U);
+  ws0[3U] = u3;
+  uint64_t u4 = load64_le(b + 32U);
+  ws0[4U] = u4;
+  uint64_t u5 = load64_le(b + 40U);
+  ws0[5U] = u5;
+  uint64_t u6 = load64_le(b + 48U);
+  ws0[6U] = u6;
+  uint64_t u7 = load64_le(b + 56U);
+  ws0[7U] = u7;
+  uint64_t u8 = load64_le(b + 64U);
+  ws0[8U] = u8;
+  uint64_t u9 = load64_le(b + 72U);
+  ws0[9U] = u9;
+  uint64_t u10 = load64_le(b + 80U);
+  ws0[10U] = u10;
+  uint64_t u11 = load64_le(b + 88U);
+  ws0[11U] = u11;
+  uint64_t u12 = load64_le(b + 96U);
+  ws0[12U] = u12;
+  uint64_t u13 = load64_le(b + 104U);
+  ws0[13U] = u13;
+  uint64_t u14 = load64_le(b + 112U);
+  ws0[14U] = u14;
+  uint64_t u15 = load64_le(b + 120U);
+  ws0[15U] = u15;
+  uint64_t u16 = load64_le(b + 128U);
+  ws0[16U] = u16;
+  uint64_t u17 = load64_le(b + 136U);
+  ws0[17U] = u17;
+  uint64_t u18 = load64_le(b + 144U);
+  ws0[18U] = u18;
+  uint64_t u19 = load64_le(b + 152U);
+  ws0[19U] = u19;
+  uint64_t u20 = load64_le(b + 160U);
+  ws0[20U] = u20;
+  uint64_t u21 = load64_le(b + 168U);
+  ws0[21U] = u21;
+  uint64_t u22 = load64_le(b + 176U);
+  ws0[22U] = u22;
+  uint64_t u23 = load64_le(b + 184U);
+  ws0[23U] = u23;
+  uint64_t u24 = load64_le(b + 192U);
+  ws0[24U] = u24;
+  uint64_t u25 = load64_le(b + 200U);
+  ws0[25U] = u25;
+  uint64_t u26 = load64_le(b + 208U);
+  ws0[26U] = u26;
+  uint64_t u27 = load64_le(b + 216U);
+  ws0[27U] = u27;
+  uint64_t u28 = load64_le(b + 224U);
+  ws0[28U] = u28;
+  uint64_t u29 = load64_le(b + 232U);
+  ws0[29U] = u29;
+  uint64_t u30 = load64_le(b + 240U);
+  ws0[30U] = u30;
+  uint64_t u31 = load64_le(b + 248U);
+  ws0[31U] = u31;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws0[i];
+  }
+  uint8_t b3[256U] = { 0U };
+  uint8_t *b4 = b3;
+  uint8_t *b0 = b4;
+  b0[rateInBytes - 1U] = 0x80U;
+  uint64_t ws1[32U] = { 0U };
+  uint8_t *b1 = b4;
+  uint64_t u = load64_le(b1);
+  ws1[0U] = u;
+  uint64_t u32 = load64_le(b1 + 8U);
+  ws1[1U] = u32;
+  uint64_t u33 = load64_le(b1 + 16U);
+  ws1[2U] = u33;
+  uint64_t u34 = load64_le(b1 + 24U);
+  ws1[3U] = u34;
+  uint64_t u35 = load64_le(b1 + 32U);
+  ws1[4U] = u35;
+  uint64_t u36 = load64_le(b1 + 40U);
+  ws1[5U] = u36;
+  uint64_t u37 = load64_le(b1 + 48U);
+  ws1[6U] = u37;
+  uint64_t u38 = load64_le(b1 + 56U);
+  ws1[7U] = u38;
+  uint64_t u39 = load64_le(b1 + 64U);
+  ws1[8U] = u39;
+  uint64_t u40 = load64_le(b1 + 72U);
+  ws1[9U] = u40;
+  uint64_t u41 = load64_le(b1 + 80U);
+  ws1[10U] = u41;
+  uint64_t u42 = load64_le(b1 + 88U);
+  ws1[11U] = u42;
+  uint64_t u43 = load64_le(b1 + 96U);
+  ws1[12U] = u43;
+  uint64_t u44 = load64_le(b1 + 104U);
+  ws1[13U] = u44;
+  uint64_t u45 = load64_le(b1 + 112U);
+  ws1[14U] = u45;
+  uint64_t u46 = load64_le(b1 + 120U);
+  ws1[15U] = u46;
+  uint64_t u47 = load64_le(b1 + 128U);
+  ws1[16U] = u47;
+  uint64_t u48 = load64_le(b1 + 136U);
+  ws1[17U] = u48;
+  uint64_t u49 = load64_le(b1 + 144U);
+  ws1[18U] = u49;
+  uint64_t u50 = load64_le(b1 + 152U);
+  ws1[19U] = u50;
+  uint64_t u51 = load64_le(b1 + 160U);
+  ws1[20U] = u51;
+  uint64_t u52 = load64_le(b1 + 168U);
+  ws1[21U] = u52;
+  uint64_t u53 = load64_le(b1 + 176U);
+  ws1[22U] = u53;
+  uint64_t u54 = load64_le(b1 + 184U);
+  ws1[23U] = u54;
+  uint64_t u55 = load64_le(b1 + 192U);
+  ws1[24U] = u55;
+  uint64_t u56 = load64_le(b1 + 200U);
+  ws1[25U] = u56;
+  uint64_t u57 = load64_le(b1 + 208U);
+  ws1[26U] = u57;
+  uint64_t u58 = load64_le(b1 + 216U);
+  ws1[27U] = u58;
+  uint64_t u59 = load64_le(b1 + 224U);
+  ws1[28U] = u59;
+  uint64_t u60 = load64_le(b1 + 232U);
+  ws1[29U] = u60;
+  uint64_t u61 = load64_le(b1 + 240U);
+  ws1[30U] = u61;
+  uint64_t u62 = load64_le(b1 + 248U);
+  ws1[31U] = u62;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws1[i];
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    uint64_t _C[5U] = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      uint64_t uu____2 = _C[(i1 + 1U) % 5U];
+      uint64_t _D = _C[(i1 + 4U) % 5U] ^ (uu____2 << 1U | uu____2 >> 63U);
+      KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i1 + 5U * i] = s[i1 + 5U * i] ^ _D;););
+    uint64_t x = s[1U];
+    uint64_t current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      uint64_t temp = s[_Y];
+      uint64_t uu____3 = current;
+      s[_Y] = uu____3 << r | uu____3 >> (64U - r);
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+      uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+      uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+      uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+      uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    s[0U] = s[0U] ^ c;
+  }
+  for (uint32_t i0 = 0U; i0 < 32U / rateInBytes; i0++)
+  {
+    uint8_t hbuf[256U] = { 0U };
+    uint64_t ws[32U] = { 0U };
+    memcpy(ws, s, 25U * sizeof (uint64_t));
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      store64_le(hbuf + i * 8U, ws[i]);
+    }
+    memcpy(output + i0 * rateInBytes, hbuf, rateInBytes * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____4 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____4 << 1U | uu____4 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____5 = current;
+        s[_Y] = uu____5 << r | uu____5 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t remOut = 32U % rateInBytes;
+  uint8_t hbuf[256U] = { 0U };
+  uint64_t ws[32U] = { 0U };
+  memcpy(ws, s, 25U * sizeof (uint64_t));
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    store64_le(hbuf + i * 8U, ws[i]);
+  }
+  memcpy(output + 32U - remOut, hbuf, remOut * sizeof (uint8_t));
+}
+
+void Hacl_Hash_SHA3_Scalar_sha3_384(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
+{
+  uint32_t rateInBytes = 104U;
+  uint64_t s[25U] = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b1[256U] = { 0U };
+    uint8_t *b_ = b1;
+    uint8_t *b0 = input;
+    uint8_t *bl0 = b_;
+    memcpy(bl0, b0 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    uint64_t ws[32U] = { 0U };
+    uint8_t *b = b_;
+    uint64_t u = load64_le(b);
+    ws[0U] = u;
+    uint64_t u0 = load64_le(b + 8U);
+    ws[1U] = u0;
+    uint64_t u1 = load64_le(b + 16U);
+    ws[2U] = u1;
+    uint64_t u2 = load64_le(b + 24U);
+    ws[3U] = u2;
+    uint64_t u3 = load64_le(b + 32U);
+    ws[4U] = u3;
+    uint64_t u4 = load64_le(b + 40U);
+    ws[5U] = u4;
+    uint64_t u5 = load64_le(b + 48U);
+    ws[6U] = u5;
+    uint64_t u6 = load64_le(b + 56U);
+    ws[7U] = u6;
+    uint64_t u7 = load64_le(b + 64U);
+    ws[8U] = u7;
+    uint64_t u8 = load64_le(b + 72U);
+    ws[9U] = u8;
+    uint64_t u9 = load64_le(b + 80U);
+    ws[10U] = u9;
+    uint64_t u10 = load64_le(b + 88U);
+    ws[11U] = u10;
+    uint64_t u11 = load64_le(b + 96U);
+    ws[12U] = u11;
+    uint64_t u12 = load64_le(b + 104U);
+    ws[13U] = u12;
+    uint64_t u13 = load64_le(b + 112U);
+    ws[14U] = u13;
+    uint64_t u14 = load64_le(b + 120U);
+    ws[15U] = u14;
+    uint64_t u15 = load64_le(b + 128U);
+    ws[16U] = u15;
+    uint64_t u16 = load64_le(b + 136U);
+    ws[17U] = u16;
+    uint64_t u17 = load64_le(b + 144U);
+    ws[18U] = u17;
+    uint64_t u18 = load64_le(b + 152U);
+    ws[19U] = u18;
+    uint64_t u19 = load64_le(b + 160U);
+    ws[20U] = u19;
+    uint64_t u20 = load64_le(b + 168U);
+    ws[21U] = u20;
+    uint64_t u21 = load64_le(b + 176U);
+    ws[22U] = u21;
+    uint64_t u22 = load64_le(b + 184U);
+    ws[23U] = u22;
+    uint64_t u23 = load64_le(b + 192U);
+    ws[24U] = u23;
+    uint64_t u24 = load64_le(b + 200U);
+    ws[25U] = u24;
+    uint64_t u25 = load64_le(b + 208U);
+    ws[26U] = u25;
+    uint64_t u26 = load64_le(b + 216U);
+    ws[27U] = u26;
+    uint64_t u27 = load64_le(b + 224U);
+    ws[28U] = u27;
+    uint64_t u28 = load64_le(b + 232U);
+    ws[29U] = u28;
+    uint64_t u29 = load64_le(b + 240U);
+    ws[30U] = u29;
+    uint64_t u30 = load64_le(b + 248U);
+    ws[31U] = u30;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = s[i] ^ ws[i];
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____0 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____0 << 1U | uu____0 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____1 = current;
+        s[_Y] = uu____1 << r | uu____1 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b2[256U] = { 0U };
+  uint8_t *b_ = b2;
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b00 = input;
+  uint8_t *bl0 = b_;
+  memcpy(bl0, b00 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b01 = b_;
+  b01[rem] = 0x06U;
+  uint64_t ws0[32U] = { 0U };
+  uint8_t *b = b_;
+  uint64_t u0 = load64_le(b);
+  ws0[0U] = u0;
+  uint64_t u1 = load64_le(b + 8U);
+  ws0[1U] = u1;
+  uint64_t u2 = load64_le(b + 16U);
+  ws0[2U] = u2;
+  uint64_t u3 = load64_le(b + 24U);
+  ws0[3U] = u3;
+  uint64_t u4 = load64_le(b + 32U);
+  ws0[4U] = u4;
+  uint64_t u5 = load64_le(b + 40U);
+  ws0[5U] = u5;
+  uint64_t u6 = load64_le(b + 48U);
+  ws0[6U] = u6;
+  uint64_t u7 = load64_le(b + 56U);
+  ws0[7U] = u7;
+  uint64_t u8 = load64_le(b + 64U);
+  ws0[8U] = u8;
+  uint64_t u9 = load64_le(b + 72U);
+  ws0[9U] = u9;
+  uint64_t u10 = load64_le(b + 80U);
+  ws0[10U] = u10;
+  uint64_t u11 = load64_le(b + 88U);
+  ws0[11U] = u11;
+  uint64_t u12 = load64_le(b + 96U);
+  ws0[12U] = u12;
+  uint64_t u13 = load64_le(b + 104U);
+  ws0[13U] = u13;
+  uint64_t u14 = load64_le(b + 112U);
+  ws0[14U] = u14;
+  uint64_t u15 = load64_le(b + 120U);
+  ws0[15U] = u15;
+  uint64_t u16 = load64_le(b + 128U);
+  ws0[16U] = u16;
+  uint64_t u17 = load64_le(b + 136U);
+  ws0[17U] = u17;
+  uint64_t u18 = load64_le(b + 144U);
+  ws0[18U] = u18;
+  uint64_t u19 = load64_le(b + 152U);
+  ws0[19U] = u19;
+  uint64_t u20 = load64_le(b + 160U);
+  ws0[20U] = u20;
+  uint64_t u21 = load64_le(b + 168U);
+  ws0[21U] = u21;
+  uint64_t u22 = load64_le(b + 176U);
+  ws0[22U] = u22;
+  uint64_t u23 = load64_le(b + 184U);
+  ws0[23U] = u23;
+  uint64_t u24 = load64_le(b + 192U);
+  ws0[24U] = u24;
+  uint64_t u25 = load64_le(b + 200U);
+  ws0[25U] = u25;
+  uint64_t u26 = load64_le(b + 208U);
+  ws0[26U] = u26;
+  uint64_t u27 = load64_le(b + 216U);
+  ws0[27U] = u27;
+  uint64_t u28 = load64_le(b + 224U);
+  ws0[28U] = u28;
+  uint64_t u29 = load64_le(b + 232U);
+  ws0[29U] = u29;
+  uint64_t u30 = load64_le(b + 240U);
+  ws0[30U] = u30;
+  uint64_t u31 = load64_le(b + 248U);
+  ws0[31U] = u31;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws0[i];
+  }
+  uint8_t b3[256U] = { 0U };
+  uint8_t *b4 = b3;
+  uint8_t *b0 = b4;
+  b0[rateInBytes - 1U] = 0x80U;
+  uint64_t ws1[32U] = { 0U };
+  uint8_t *b1 = b4;
+  uint64_t u = load64_le(b1);
+  ws1[0U] = u;
+  uint64_t u32 = load64_le(b1 + 8U);
+  ws1[1U] = u32;
+  uint64_t u33 = load64_le(b1 + 16U);
+  ws1[2U] = u33;
+  uint64_t u34 = load64_le(b1 + 24U);
+  ws1[3U] = u34;
+  uint64_t u35 = load64_le(b1 + 32U);
+  ws1[4U] = u35;
+  uint64_t u36 = load64_le(b1 + 40U);
+  ws1[5U] = u36;
+  uint64_t u37 = load64_le(b1 + 48U);
+  ws1[6U] = u37;
+  uint64_t u38 = load64_le(b1 + 56U);
+  ws1[7U] = u38;
+  uint64_t u39 = load64_le(b1 + 64U);
+  ws1[8U] = u39;
+  uint64_t u40 = load64_le(b1 + 72U);
+  ws1[9U] = u40;
+  uint64_t u41 = load64_le(b1 + 80U);
+  ws1[10U] = u41;
+  uint64_t u42 = load64_le(b1 + 88U);
+  ws1[11U] = u42;
+  uint64_t u43 = load64_le(b1 + 96U);
+  ws1[12U] = u43;
+  uint64_t u44 = load64_le(b1 + 104U);
+  ws1[13U] = u44;
+  uint64_t u45 = load64_le(b1 + 112U);
+  ws1[14U] = u45;
+  uint64_t u46 = load64_le(b1 + 120U);
+  ws1[15U] = u46;
+  uint64_t u47 = load64_le(b1 + 128U);
+  ws1[16U] = u47;
+  uint64_t u48 = load64_le(b1 + 136U);
+  ws1[17U] = u48;
+  uint64_t u49 = load64_le(b1 + 144U);
+  ws1[18U] = u49;
+  uint64_t u50 = load64_le(b1 + 152U);
+  ws1[19U] = u50;
+  uint64_t u51 = load64_le(b1 + 160U);
+  ws1[20U] = u51;
+  uint64_t u52 = load64_le(b1 + 168U);
+  ws1[21U] = u52;
+  uint64_t u53 = load64_le(b1 + 176U);
+  ws1[22U] = u53;
+  uint64_t u54 = load64_le(b1 + 184U);
+  ws1[23U] = u54;
+  uint64_t u55 = load64_le(b1 + 192U);
+  ws1[24U] = u55;
+  uint64_t u56 = load64_le(b1 + 200U);
+  ws1[25U] = u56;
+  uint64_t u57 = load64_le(b1 + 208U);
+  ws1[26U] = u57;
+  uint64_t u58 = load64_le(b1 + 216U);
+  ws1[27U] = u58;
+  uint64_t u59 = load64_le(b1 + 224U);
+  ws1[28U] = u59;
+  uint64_t u60 = load64_le(b1 + 232U);
+  ws1[29U] = u60;
+  uint64_t u61 = load64_le(b1 + 240U);
+  ws1[30U] = u61;
+  uint64_t u62 = load64_le(b1 + 248U);
+  ws1[31U] = u62;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws1[i];
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    uint64_t _C[5U] = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      uint64_t uu____2 = _C[(i1 + 1U) % 5U];
+      uint64_t _D = _C[(i1 + 4U) % 5U] ^ (uu____2 << 1U | uu____2 >> 63U);
+      KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i1 + 5U * i] = s[i1 + 5U * i] ^ _D;););
+    uint64_t x = s[1U];
+    uint64_t current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      uint64_t temp = s[_Y];
+      uint64_t uu____3 = current;
+      s[_Y] = uu____3 << r | uu____3 >> (64U - r);
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+      uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+      uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+      uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+      uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    s[0U] = s[0U] ^ c;
+  }
+  for (uint32_t i0 = 0U; i0 < 48U / rateInBytes; i0++)
+  {
+    uint8_t hbuf[256U] = { 0U };
+    uint64_t ws[32U] = { 0U };
+    memcpy(ws, s, 25U * sizeof (uint64_t));
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      store64_le(hbuf + i * 8U, ws[i]);
+    }
+    memcpy(output + i0 * rateInBytes, hbuf, rateInBytes * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____4 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____4 << 1U | uu____4 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____5 = current;
+        s[_Y] = uu____5 << r | uu____5 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t remOut = 48U % rateInBytes;
+  uint8_t hbuf[256U] = { 0U };
+  uint64_t ws[32U] = { 0U };
+  memcpy(ws, s, 25U * sizeof (uint64_t));
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    store64_le(hbuf + i * 8U, ws[i]);
+  }
+  memcpy(output + 48U - remOut, hbuf, remOut * sizeof (uint8_t));
+}
+
+void Hacl_Hash_SHA3_Scalar_sha3_512(uint32_t inputByteLen, uint8_t *input, uint8_t *output)
+{
+  uint32_t rateInBytes = 72U;
+  uint64_t s[25U] = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b1[256U] = { 0U };
+    uint8_t *b_ = b1;
+    uint8_t *b0 = input;
+    uint8_t *bl0 = b_;
+    memcpy(bl0, b0 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    uint64_t ws[32U] = { 0U };
+    uint8_t *b = b_;
+    uint64_t u = load64_le(b);
+    ws[0U] = u;
+    uint64_t u0 = load64_le(b + 8U);
+    ws[1U] = u0;
+    uint64_t u1 = load64_le(b + 16U);
+    ws[2U] = u1;
+    uint64_t u2 = load64_le(b + 24U);
+    ws[3U] = u2;
+    uint64_t u3 = load64_le(b + 32U);
+    ws[4U] = u3;
+    uint64_t u4 = load64_le(b + 40U);
+    ws[5U] = u4;
+    uint64_t u5 = load64_le(b + 48U);
+    ws[6U] = u5;
+    uint64_t u6 = load64_le(b + 56U);
+    ws[7U] = u6;
+    uint64_t u7 = load64_le(b + 64U);
+    ws[8U] = u7;
+    uint64_t u8 = load64_le(b + 72U);
+    ws[9U] = u8;
+    uint64_t u9 = load64_le(b + 80U);
+    ws[10U] = u9;
+    uint64_t u10 = load64_le(b + 88U);
+    ws[11U] = u10;
+    uint64_t u11 = load64_le(b + 96U);
+    ws[12U] = u11;
+    uint64_t u12 = load64_le(b + 104U);
+    ws[13U] = u12;
+    uint64_t u13 = load64_le(b + 112U);
+    ws[14U] = u13;
+    uint64_t u14 = load64_le(b + 120U);
+    ws[15U] = u14;
+    uint64_t u15 = load64_le(b + 128U);
+    ws[16U] = u15;
+    uint64_t u16 = load64_le(b + 136U);
+    ws[17U] = u16;
+    uint64_t u17 = load64_le(b + 144U);
+    ws[18U] = u17;
+    uint64_t u18 = load64_le(b + 152U);
+    ws[19U] = u18;
+    uint64_t u19 = load64_le(b + 160U);
+    ws[20U] = u19;
+    uint64_t u20 = load64_le(b + 168U);
+    ws[21U] = u20;
+    uint64_t u21 = load64_le(b + 176U);
+    ws[22U] = u21;
+    uint64_t u22 = load64_le(b + 184U);
+    ws[23U] = u22;
+    uint64_t u23 = load64_le(b + 192U);
+    ws[24U] = u23;
+    uint64_t u24 = load64_le(b + 200U);
+    ws[25U] = u24;
+    uint64_t u25 = load64_le(b + 208U);
+    ws[26U] = u25;
+    uint64_t u26 = load64_le(b + 216U);
+    ws[27U] = u26;
+    uint64_t u27 = load64_le(b + 224U);
+    ws[28U] = u27;
+    uint64_t u28 = load64_le(b + 232U);
+    ws[29U] = u28;
+    uint64_t u29 = load64_le(b + 240U);
+    ws[30U] = u29;
+    uint64_t u30 = load64_le(b + 248U);
+    ws[31U] = u30;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = s[i] ^ ws[i];
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____0 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____0 << 1U | uu____0 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____1 = current;
+        s[_Y] = uu____1 << r | uu____1 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b2[256U] = { 0U };
+  uint8_t *b_ = b2;
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b00 = input;
+  uint8_t *bl0 = b_;
+  memcpy(bl0, b00 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b01 = b_;
+  b01[rem] = 0x06U;
+  uint64_t ws0[32U] = { 0U };
+  uint8_t *b = b_;
+  uint64_t u0 = load64_le(b);
+  ws0[0U] = u0;
+  uint64_t u1 = load64_le(b + 8U);
+  ws0[1U] = u1;
+  uint64_t u2 = load64_le(b + 16U);
+  ws0[2U] = u2;
+  uint64_t u3 = load64_le(b + 24U);
+  ws0[3U] = u3;
+  uint64_t u4 = load64_le(b + 32U);
+  ws0[4U] = u4;
+  uint64_t u5 = load64_le(b + 40U);
+  ws0[5U] = u5;
+  uint64_t u6 = load64_le(b + 48U);
+  ws0[6U] = u6;
+  uint64_t u7 = load64_le(b + 56U);
+  ws0[7U] = u7;
+  uint64_t u8 = load64_le(b + 64U);
+  ws0[8U] = u8;
+  uint64_t u9 = load64_le(b + 72U);
+  ws0[9U] = u9;
+  uint64_t u10 = load64_le(b + 80U);
+  ws0[10U] = u10;
+  uint64_t u11 = load64_le(b + 88U);
+  ws0[11U] = u11;
+  uint64_t u12 = load64_le(b + 96U);
+  ws0[12U] = u12;
+  uint64_t u13 = load64_le(b + 104U);
+  ws0[13U] = u13;
+  uint64_t u14 = load64_le(b + 112U);
+  ws0[14U] = u14;
+  uint64_t u15 = load64_le(b + 120U);
+  ws0[15U] = u15;
+  uint64_t u16 = load64_le(b + 128U);
+  ws0[16U] = u16;
+  uint64_t u17 = load64_le(b + 136U);
+  ws0[17U] = u17;
+  uint64_t u18 = load64_le(b + 144U);
+  ws0[18U] = u18;
+  uint64_t u19 = load64_le(b + 152U);
+  ws0[19U] = u19;
+  uint64_t u20 = load64_le(b + 160U);
+  ws0[20U] = u20;
+  uint64_t u21 = load64_le(b + 168U);
+  ws0[21U] = u21;
+  uint64_t u22 = load64_le(b + 176U);
+  ws0[22U] = u22;
+  uint64_t u23 = load64_le(b + 184U);
+  ws0[23U] = u23;
+  uint64_t u24 = load64_le(b + 192U);
+  ws0[24U] = u24;
+  uint64_t u25 = load64_le(b + 200U);
+  ws0[25U] = u25;
+  uint64_t u26 = load64_le(b + 208U);
+  ws0[26U] = u26;
+  uint64_t u27 = load64_le(b + 216U);
+  ws0[27U] = u27;
+  uint64_t u28 = load64_le(b + 224U);
+  ws0[28U] = u28;
+  uint64_t u29 = load64_le(b + 232U);
+  ws0[29U] = u29;
+  uint64_t u30 = load64_le(b + 240U);
+  ws0[30U] = u30;
+  uint64_t u31 = load64_le(b + 248U);
+  ws0[31U] = u31;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws0[i];
+  }
+  uint8_t b3[256U] = { 0U };
+  uint8_t *b4 = b3;
+  uint8_t *b0 = b4;
+  b0[rateInBytes - 1U] = 0x80U;
+  uint64_t ws1[32U] = { 0U };
+  uint8_t *b1 = b4;
+  uint64_t u = load64_le(b1);
+  ws1[0U] = u;
+  uint64_t u32 = load64_le(b1 + 8U);
+  ws1[1U] = u32;
+  uint64_t u33 = load64_le(b1 + 16U);
+  ws1[2U] = u33;
+  uint64_t u34 = load64_le(b1 + 24U);
+  ws1[3U] = u34;
+  uint64_t u35 = load64_le(b1 + 32U);
+  ws1[4U] = u35;
+  uint64_t u36 = load64_le(b1 + 40U);
+  ws1[5U] = u36;
+  uint64_t u37 = load64_le(b1 + 48U);
+  ws1[6U] = u37;
+  uint64_t u38 = load64_le(b1 + 56U);
+  ws1[7U] = u38;
+  uint64_t u39 = load64_le(b1 + 64U);
+  ws1[8U] = u39;
+  uint64_t u40 = load64_le(b1 + 72U);
+  ws1[9U] = u40;
+  uint64_t u41 = load64_le(b1 + 80U);
+  ws1[10U] = u41;
+  uint64_t u42 = load64_le(b1 + 88U);
+  ws1[11U] = u42;
+  uint64_t u43 = load64_le(b1 + 96U);
+  ws1[12U] = u43;
+  uint64_t u44 = load64_le(b1 + 104U);
+  ws1[13U] = u44;
+  uint64_t u45 = load64_le(b1 + 112U);
+  ws1[14U] = u45;
+  uint64_t u46 = load64_le(b1 + 120U);
+  ws1[15U] = u46;
+  uint64_t u47 = load64_le(b1 + 128U);
+  ws1[16U] = u47;
+  uint64_t u48 = load64_le(b1 + 136U);
+  ws1[17U] = u48;
+  uint64_t u49 = load64_le(b1 + 144U);
+  ws1[18U] = u49;
+  uint64_t u50 = load64_le(b1 + 152U);
+  ws1[19U] = u50;
+  uint64_t u51 = load64_le(b1 + 160U);
+  ws1[20U] = u51;
+  uint64_t u52 = load64_le(b1 + 168U);
+  ws1[21U] = u52;
+  uint64_t u53 = load64_le(b1 + 176U);
+  ws1[22U] = u53;
+  uint64_t u54 = load64_le(b1 + 184U);
+  ws1[23U] = u54;
+  uint64_t u55 = load64_le(b1 + 192U);
+  ws1[24U] = u55;
+  uint64_t u56 = load64_le(b1 + 200U);
+  ws1[25U] = u56;
+  uint64_t u57 = load64_le(b1 + 208U);
+  ws1[26U] = u57;
+  uint64_t u58 = load64_le(b1 + 216U);
+  ws1[27U] = u58;
+  uint64_t u59 = load64_le(b1 + 224U);
+  ws1[28U] = u59;
+  uint64_t u60 = load64_le(b1 + 232U);
+  ws1[29U] = u60;
+  uint64_t u61 = load64_le(b1 + 240U);
+  ws1[30U] = u61;
+  uint64_t u62 = load64_le(b1 + 248U);
+  ws1[31U] = u62;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = s[i] ^ ws1[i];
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    uint64_t _C[5U] = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      uint64_t uu____2 = _C[(i1 + 1U) % 5U];
+      uint64_t _D = _C[(i1 + 4U) % 5U] ^ (uu____2 << 1U | uu____2 >> 63U);
+      KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i1 + 5U * i] = s[i1 + 5U * i] ^ _D;););
+    uint64_t x = s[1U];
+    uint64_t current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      uint64_t temp = s[_Y];
+      uint64_t uu____3 = current;
+      s[_Y] = uu____3 << r | uu____3 >> (64U - r);
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+      uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+      uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+      uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+      uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    s[0U] = s[0U] ^ c;
+  }
+  for (uint32_t i0 = 0U; i0 < 64U / rateInBytes; i0++)
+  {
+    uint8_t hbuf[256U] = { 0U };
+    uint64_t ws[32U] = { 0U };
+    memcpy(ws, s, 25U * sizeof (uint64_t));
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      store64_le(hbuf + i * 8U, ws[i]);
+    }
+    memcpy(output + i0 * rateInBytes, hbuf, rateInBytes * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      uint64_t _C[5U] = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        _C[i] = s[i + 0U] ^ (s[i + 5U] ^ (s[i + 10U] ^ (s[i + 15U] ^ s[i + 20U]))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        uint64_t uu____4 = _C[(i2 + 1U) % 5U];
+        uint64_t _D = _C[(i2 + 4U) % 5U] ^ (uu____4 << 1U | uu____4 >> 63U);
+        KRML_MAYBE_FOR5(i, 0U, 5U, 1U, s[i2 + 5U * i] = s[i2 + 5U * i] ^ _D;););
+      uint64_t x = s[1U];
+      uint64_t current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        uint64_t temp = s[_Y];
+        uint64_t uu____5 = current;
+        s[_Y] = uu____5 << r | uu____5 >> (64U - r);
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        uint64_t v0 = s[0U + 5U * i] ^ (~s[1U + 5U * i] & s[2U + 5U * i]);
+        uint64_t v1 = s[1U + 5U * i] ^ (~s[2U + 5U * i] & s[3U + 5U * i]);
+        uint64_t v2 = s[2U + 5U * i] ^ (~s[3U + 5U * i] & s[4U + 5U * i]);
+        uint64_t v3 = s[3U + 5U * i] ^ (~s[4U + 5U * i] & s[0U + 5U * i]);
+        uint64_t v4 = s[4U + 5U * i] ^ (~s[0U + 5U * i] & s[1U + 5U * i]);
+        s[0U + 5U * i] = v0;
+        s[1U + 5U * i] = v1;
+        s[2U + 5U * i] = v2;
+        s[3U + 5U * i] = v3;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      s[0U] = s[0U] ^ c;
+    }
+  }
+  uint32_t remOut = 64U % rateInBytes;
+  uint8_t hbuf[256U] = { 0U };
+  uint64_t ws[32U] = { 0U };
+  memcpy(ws, s, 25U * sizeof (uint64_t));
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    store64_le(hbuf + i * 8U, ws[i]);
+  }
+  memcpy(output + 64U - remOut, hbuf, remOut * sizeof (uint8_t));
+}
+

--- a/src/msvc/Hacl_Hash_SHA3_Simd256.c
+++ b/src/msvc/Hacl_Hash_SHA3_Simd256.c
@@ -1,0 +1,10076 @@
+/* MIT License
+ *
+ * Copyright (c) 2016-2022 INRIA, CMU and Microsoft Corporation
+ * Copyright (c) 2022-2023 HACL* Contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include "Hacl_Hash_SHA3_Simd256.h"
+
+#include "internal/Hacl_Hash_SHA3_Scalar.h"
+#include "libintvector.h"
+
+void
+Hacl_Hash_SHA3_Simd256_shake128(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint32_t outputByteLen,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+)
+{
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  rb = { .fst = output0, .snd = { .fst = output1, .snd = { .fst = output2, .snd = output3 } } };
+  uint32_t rateInBytes = 168U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 s[25U] KRML_POST_ALIGN(32) = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b00[256U] = { 0U };
+    uint8_t b10[256U] = { 0U };
+    uint8_t b20[256U] = { 0U };
+    uint8_t b30[256U] = { 0U };
+    K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+    b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+    uint8_t *b31 = ib.snd.snd.snd;
+    uint8_t *b21 = ib.snd.snd.fst;
+    uint8_t *b11 = ib.snd.fst;
+    uint8_t *b01 = ib.fst;
+    uint8_t *bl3 = b_.snd.snd.snd;
+    uint8_t *bl2 = b_.snd.snd.fst;
+    uint8_t *bl1 = b_.snd.fst;
+    uint8_t *bl0 = b_.fst;
+    memcpy(bl0, b01 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl1, b11 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl2, b21 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl3, b31 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    uint8_t *b3 = b_.snd.snd.snd;
+    uint8_t *b2 = b_.snd.snd.fst;
+    uint8_t *b1 = b_.snd.fst;
+    uint8_t *b0 = b_.fst;
+    ws[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0);
+    ws[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1);
+    ws[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2);
+    ws[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3);
+    ws[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 32U);
+    ws[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 32U);
+    ws[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 32U);
+    ws[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 32U);
+    ws[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 64U);
+    ws[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 64U);
+    ws[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 64U);
+    ws[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 64U);
+    ws[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 96U);
+    ws[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 96U);
+    ws[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 96U);
+    ws[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 96U);
+    ws[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 128U);
+    ws[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 128U);
+    ws[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 128U);
+    ws[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 128U);
+    ws[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 160U);
+    ws[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 160U);
+    ws[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 160U);
+    ws[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 160U);
+    ws[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 192U);
+    ws[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 192U);
+    ws[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 192U);
+    ws[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 192U);
+    ws[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 224U);
+    ws[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 224U);
+    ws[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 224U);
+    ws[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 224U);
+    Lib_IntVector_Intrinsics_vec256 v00 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v10 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v20 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v30 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256
+    v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__;
+    Lib_IntVector_Intrinsics_vec256 v01 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v11 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v21 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v31 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256
+    v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__0;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__0;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__0;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__0;
+    Lib_IntVector_Intrinsics_vec256 v02 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v12 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v22 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v32 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256
+    v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__1;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__1;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__1;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__1;
+    Lib_IntVector_Intrinsics_vec256 v03 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v13 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v23 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v33 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256
+    v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__2;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__2;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__2;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__2;
+    Lib_IntVector_Intrinsics_vec256 v04 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v14 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v24 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v34 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256
+    v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__3;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__3;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__3;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__3;
+    Lib_IntVector_Intrinsics_vec256 v05 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v15 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v25 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v35 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256
+    v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__4;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__4;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__4;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__4;
+    Lib_IntVector_Intrinsics_vec256 v06 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v16 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v26 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v36 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256
+    v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__5;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__5;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__5;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__5;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256
+    v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__6;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__6;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__6;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__6;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws[i]);
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____0 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____1 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____2 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____0,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____1,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____2,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____3 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____4 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____3,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____4,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____4, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____5 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____5,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____5, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____6 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____7 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v07 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____6,
+            Lib_IntVector_Intrinsics_vec256_and(uu____7, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____8 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____9 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v17 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____8,
+            Lib_IntVector_Intrinsics_vec256_and(uu____9, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____10 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____11 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v27 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____10,
+            Lib_IntVector_Intrinsics_vec256_and(uu____11, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____12 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____13 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v37 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____12,
+            Lib_IntVector_Intrinsics_vec256_and(uu____13, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____14 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____15 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____14,
+            Lib_IntVector_Intrinsics_vec256_and(uu____15, s[1U + 5U * i]));
+        s[0U + 5U * i] = v07;
+        s[1U + 5U * i] = v17;
+        s[2U + 5U * i] = v27;
+        s[3U + 5U * i] = v37;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____16 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____16,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b00[256U] = { 0U };
+  uint8_t b10[256U] = { 0U };
+  uint8_t b20[256U] = { 0U };
+  uint8_t b30[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b32 = ib.snd.snd.snd;
+  uint8_t *b22 = ib.snd.snd.fst;
+  uint8_t *b12 = ib.snd.fst;
+  uint8_t *b02 = ib.fst;
+  uint8_t *bl3 = b_.snd.snd.snd;
+  uint8_t *bl2 = b_.snd.snd.fst;
+  uint8_t *bl1 = b_.snd.fst;
+  uint8_t *bl0 = b_.fst;
+  memcpy(bl0, b02 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl1, b12 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl2, b22 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl3, b32 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b33 = b_.snd.snd.snd;
+  uint8_t *b23 = b_.snd.snd.fst;
+  uint8_t *b13 = b_.snd.fst;
+  uint8_t *b03 = b_.fst;
+  b03[rem] = 0x1FU;
+  b13[rem] = 0x1FU;
+  b23[rem] = 0x1FU;
+  b33[rem] = 0x1FU;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws32[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b34 = b_.snd.snd.snd;
+  uint8_t *b24 = b_.snd.snd.fst;
+  uint8_t *b14 = b_.snd.fst;
+  uint8_t *b04 = b_.fst;
+  ws32[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04);
+  ws32[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14);
+  ws32[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24);
+  ws32[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34);
+  ws32[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 32U);
+  ws32[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 32U);
+  ws32[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 32U);
+  ws32[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 32U);
+  ws32[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 64U);
+  ws32[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 64U);
+  ws32[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 64U);
+  ws32[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 64U);
+  ws32[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 96U);
+  ws32[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 96U);
+  ws32[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 96U);
+  ws32[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 96U);
+  ws32[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 128U);
+  ws32[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 128U);
+  ws32[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 128U);
+  ws32[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 128U);
+  ws32[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 160U);
+  ws32[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 160U);
+  ws32[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 160U);
+  ws32[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 160U);
+  ws32[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 192U);
+  ws32[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 192U);
+  ws32[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 192U);
+  ws32[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 192U);
+  ws32[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 224U);
+  ws32[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 224U);
+  ws32[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 224U);
+  ws32[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v00 = ws32[0U];
+  Lib_IntVector_Intrinsics_vec256 v10 = ws32[1U];
+  Lib_IntVector_Intrinsics_vec256 v20 = ws32[2U];
+  Lib_IntVector_Intrinsics_vec256 v30 = ws32[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256
+  v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256 ws00 = v0__;
+  Lib_IntVector_Intrinsics_vec256 ws110 = v2__;
+  Lib_IntVector_Intrinsics_vec256 ws210 = v1__;
+  Lib_IntVector_Intrinsics_vec256 ws33 = v3__;
+  Lib_IntVector_Intrinsics_vec256 v01 = ws32[4U];
+  Lib_IntVector_Intrinsics_vec256 v11 = ws32[5U];
+  Lib_IntVector_Intrinsics_vec256 v21 = ws32[6U];
+  Lib_IntVector_Intrinsics_vec256 v31 = ws32[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256
+  v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256 ws40 = v0__0;
+  Lib_IntVector_Intrinsics_vec256 ws50 = v2__0;
+  Lib_IntVector_Intrinsics_vec256 ws60 = v1__0;
+  Lib_IntVector_Intrinsics_vec256 ws70 = v3__0;
+  Lib_IntVector_Intrinsics_vec256 v02 = ws32[8U];
+  Lib_IntVector_Intrinsics_vec256 v12 = ws32[9U];
+  Lib_IntVector_Intrinsics_vec256 v22 = ws32[10U];
+  Lib_IntVector_Intrinsics_vec256 v32 = ws32[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256
+  v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256 ws80 = v0__1;
+  Lib_IntVector_Intrinsics_vec256 ws90 = v2__1;
+  Lib_IntVector_Intrinsics_vec256 ws100 = v1__1;
+  Lib_IntVector_Intrinsics_vec256 ws111 = v3__1;
+  Lib_IntVector_Intrinsics_vec256 v03 = ws32[12U];
+  Lib_IntVector_Intrinsics_vec256 v13 = ws32[13U];
+  Lib_IntVector_Intrinsics_vec256 v23 = ws32[14U];
+  Lib_IntVector_Intrinsics_vec256 v33 = ws32[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256
+  v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256 ws120 = v0__2;
+  Lib_IntVector_Intrinsics_vec256 ws130 = v2__2;
+  Lib_IntVector_Intrinsics_vec256 ws140 = v1__2;
+  Lib_IntVector_Intrinsics_vec256 ws150 = v3__2;
+  Lib_IntVector_Intrinsics_vec256 v04 = ws32[16U];
+  Lib_IntVector_Intrinsics_vec256 v14 = ws32[17U];
+  Lib_IntVector_Intrinsics_vec256 v24 = ws32[18U];
+  Lib_IntVector_Intrinsics_vec256 v34 = ws32[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256
+  v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256 ws160 = v0__3;
+  Lib_IntVector_Intrinsics_vec256 ws170 = v2__3;
+  Lib_IntVector_Intrinsics_vec256 ws180 = v1__3;
+  Lib_IntVector_Intrinsics_vec256 ws190 = v3__3;
+  Lib_IntVector_Intrinsics_vec256 v05 = ws32[20U];
+  Lib_IntVector_Intrinsics_vec256 v15 = ws32[21U];
+  Lib_IntVector_Intrinsics_vec256 v25 = ws32[22U];
+  Lib_IntVector_Intrinsics_vec256 v35 = ws32[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256
+  v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256 ws200 = v0__4;
+  Lib_IntVector_Intrinsics_vec256 ws211 = v2__4;
+  Lib_IntVector_Intrinsics_vec256 ws220 = v1__4;
+  Lib_IntVector_Intrinsics_vec256 ws230 = v3__4;
+  Lib_IntVector_Intrinsics_vec256 v06 = ws32[24U];
+  Lib_IntVector_Intrinsics_vec256 v16 = ws32[25U];
+  Lib_IntVector_Intrinsics_vec256 v26 = ws32[26U];
+  Lib_IntVector_Intrinsics_vec256 v36 = ws32[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256
+  v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256 ws240 = v0__5;
+  Lib_IntVector_Intrinsics_vec256 ws250 = v2__5;
+  Lib_IntVector_Intrinsics_vec256 ws260 = v1__5;
+  Lib_IntVector_Intrinsics_vec256 ws270 = v3__5;
+  Lib_IntVector_Intrinsics_vec256 v07 = ws32[28U];
+  Lib_IntVector_Intrinsics_vec256 v17 = ws32[29U];
+  Lib_IntVector_Intrinsics_vec256 v27 = ws32[30U];
+  Lib_IntVector_Intrinsics_vec256 v37 = ws32[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256
+  v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256 ws280 = v0__6;
+  Lib_IntVector_Intrinsics_vec256 ws290 = v2__6;
+  Lib_IntVector_Intrinsics_vec256 ws300 = v1__6;
+  Lib_IntVector_Intrinsics_vec256 ws310 = v3__6;
+  ws32[0U] = ws00;
+  ws32[1U] = ws110;
+  ws32[2U] = ws210;
+  ws32[3U] = ws33;
+  ws32[4U] = ws40;
+  ws32[5U] = ws50;
+  ws32[6U] = ws60;
+  ws32[7U] = ws70;
+  ws32[8U] = ws80;
+  ws32[9U] = ws90;
+  ws32[10U] = ws100;
+  ws32[11U] = ws111;
+  ws32[12U] = ws120;
+  ws32[13U] = ws130;
+  ws32[14U] = ws140;
+  ws32[15U] = ws150;
+  ws32[16U] = ws160;
+  ws32[17U] = ws170;
+  ws32[18U] = ws180;
+  ws32[19U] = ws190;
+  ws32[20U] = ws200;
+  ws32[21U] = ws211;
+  ws32[22U] = ws220;
+  ws32[23U] = ws230;
+  ws32[24U] = ws240;
+  ws32[25U] = ws250;
+  ws32[26U] = ws260;
+  ws32[27U] = ws270;
+  ws32[28U] = ws280;
+  ws32[29U] = ws290;
+  ws32[30U] = ws300;
+  ws32[31U] = ws310;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws32[i]);
+  }
+  uint8_t b05[256U] = { 0U };
+  uint8_t b15[256U] = { 0U };
+  uint8_t b25[256U] = { 0U };
+  uint8_t b35[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b = { .fst = b05, .snd = { .fst = b15, .snd = { .fst = b25, .snd = b35 } } };
+  uint8_t *b36 = b.snd.snd.snd;
+  uint8_t *b26 = b.snd.snd.fst;
+  uint8_t *b16 = b.snd.fst;
+  uint8_t *b06 = b.fst;
+  b06[rateInBytes - 1U] = 0x80U;
+  b16[rateInBytes - 1U] = 0x80U;
+  b26[rateInBytes - 1U] = 0x80U;
+  b36[rateInBytes - 1U] = 0x80U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws34[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b37 = b.snd.snd.snd;
+  uint8_t *b27 = b.snd.snd.fst;
+  uint8_t *b17 = b.snd.fst;
+  uint8_t *b07 = b.fst;
+  ws34[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07);
+  ws34[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17);
+  ws34[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27);
+  ws34[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37);
+  ws34[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 32U);
+  ws34[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 32U);
+  ws34[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 32U);
+  ws34[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 32U);
+  ws34[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 64U);
+  ws34[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 64U);
+  ws34[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 64U);
+  ws34[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 64U);
+  ws34[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 96U);
+  ws34[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 96U);
+  ws34[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 96U);
+  ws34[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 96U);
+  ws34[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 128U);
+  ws34[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 128U);
+  ws34[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 128U);
+  ws34[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 128U);
+  ws34[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 160U);
+  ws34[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 160U);
+  ws34[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 160U);
+  ws34[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 160U);
+  ws34[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 192U);
+  ws34[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 192U);
+  ws34[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 192U);
+  ws34[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 192U);
+  ws34[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 224U);
+  ws34[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 224U);
+  ws34[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 224U);
+  ws34[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v08 = ws34[0U];
+  Lib_IntVector_Intrinsics_vec256 v18 = ws34[1U];
+  Lib_IntVector_Intrinsics_vec256 v28 = ws34[2U];
+  Lib_IntVector_Intrinsics_vec256 v38 = ws34[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v1_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v2_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v3_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v0__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v1__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v2__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256
+  v3__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256 ws01 = v0__7;
+  Lib_IntVector_Intrinsics_vec256 ws112 = v2__7;
+  Lib_IntVector_Intrinsics_vec256 ws212 = v1__7;
+  Lib_IntVector_Intrinsics_vec256 ws35 = v3__7;
+  Lib_IntVector_Intrinsics_vec256 v09 = ws34[4U];
+  Lib_IntVector_Intrinsics_vec256 v19 = ws34[5U];
+  Lib_IntVector_Intrinsics_vec256 v29 = ws34[6U];
+  Lib_IntVector_Intrinsics_vec256 v39 = ws34[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v1_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v2_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v3_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v0__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v1__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v2__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256
+  v3__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256 ws41 = v0__8;
+  Lib_IntVector_Intrinsics_vec256 ws51 = v2__8;
+  Lib_IntVector_Intrinsics_vec256 ws61 = v1__8;
+  Lib_IntVector_Intrinsics_vec256 ws71 = v3__8;
+  Lib_IntVector_Intrinsics_vec256 v010 = ws34[8U];
+  Lib_IntVector_Intrinsics_vec256 v110 = ws34[9U];
+  Lib_IntVector_Intrinsics_vec256 v210 = ws34[10U];
+  Lib_IntVector_Intrinsics_vec256 v310 = ws34[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v1_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v2_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v3_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v0__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v1__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v2__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256
+  v3__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256 ws81 = v0__9;
+  Lib_IntVector_Intrinsics_vec256 ws91 = v2__9;
+  Lib_IntVector_Intrinsics_vec256 ws101 = v1__9;
+  Lib_IntVector_Intrinsics_vec256 ws113 = v3__9;
+  Lib_IntVector_Intrinsics_vec256 v011 = ws34[12U];
+  Lib_IntVector_Intrinsics_vec256 v111 = ws34[13U];
+  Lib_IntVector_Intrinsics_vec256 v211 = ws34[14U];
+  Lib_IntVector_Intrinsics_vec256 v311 = ws34[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v1_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v2_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v3_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v0__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v1__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v2__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256
+  v3__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256 ws121 = v0__10;
+  Lib_IntVector_Intrinsics_vec256 ws131 = v2__10;
+  Lib_IntVector_Intrinsics_vec256 ws141 = v1__10;
+  Lib_IntVector_Intrinsics_vec256 ws151 = v3__10;
+  Lib_IntVector_Intrinsics_vec256 v012 = ws34[16U];
+  Lib_IntVector_Intrinsics_vec256 v112 = ws34[17U];
+  Lib_IntVector_Intrinsics_vec256 v212 = ws34[18U];
+  Lib_IntVector_Intrinsics_vec256 v312 = ws34[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v1_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v2_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v3_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v0__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v1__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v2__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256
+  v3__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256 ws161 = v0__11;
+  Lib_IntVector_Intrinsics_vec256 ws171 = v2__11;
+  Lib_IntVector_Intrinsics_vec256 ws181 = v1__11;
+  Lib_IntVector_Intrinsics_vec256 ws191 = v3__11;
+  Lib_IntVector_Intrinsics_vec256 v013 = ws34[20U];
+  Lib_IntVector_Intrinsics_vec256 v113 = ws34[21U];
+  Lib_IntVector_Intrinsics_vec256 v213 = ws34[22U];
+  Lib_IntVector_Intrinsics_vec256 v313 = ws34[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v1_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v2_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v3_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v0__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v1__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v2__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256
+  v3__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256 ws201 = v0__12;
+  Lib_IntVector_Intrinsics_vec256 ws213 = v2__12;
+  Lib_IntVector_Intrinsics_vec256 ws221 = v1__12;
+  Lib_IntVector_Intrinsics_vec256 ws231 = v3__12;
+  Lib_IntVector_Intrinsics_vec256 v014 = ws34[24U];
+  Lib_IntVector_Intrinsics_vec256 v114 = ws34[25U];
+  Lib_IntVector_Intrinsics_vec256 v214 = ws34[26U];
+  Lib_IntVector_Intrinsics_vec256 v314 = ws34[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v1_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v2_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v3_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v0__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v1__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v2__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256
+  v3__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256 ws241 = v0__13;
+  Lib_IntVector_Intrinsics_vec256 ws251 = v2__13;
+  Lib_IntVector_Intrinsics_vec256 ws261 = v1__13;
+  Lib_IntVector_Intrinsics_vec256 ws271 = v3__13;
+  Lib_IntVector_Intrinsics_vec256 v015 = ws34[28U];
+  Lib_IntVector_Intrinsics_vec256 v115 = ws34[29U];
+  Lib_IntVector_Intrinsics_vec256 v215 = ws34[30U];
+  Lib_IntVector_Intrinsics_vec256 v315 = ws34[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v1_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v2_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v3_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v0__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v1__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v2__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256
+  v3__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256 ws281 = v0__14;
+  Lib_IntVector_Intrinsics_vec256 ws291 = v2__14;
+  Lib_IntVector_Intrinsics_vec256 ws301 = v1__14;
+  Lib_IntVector_Intrinsics_vec256 ws311 = v3__14;
+  ws34[0U] = ws01;
+  ws34[1U] = ws112;
+  ws34[2U] = ws212;
+  ws34[3U] = ws35;
+  ws34[4U] = ws41;
+  ws34[5U] = ws51;
+  ws34[6U] = ws61;
+  ws34[7U] = ws71;
+  ws34[8U] = ws81;
+  ws34[9U] = ws91;
+  ws34[10U] = ws101;
+  ws34[11U] = ws113;
+  ws34[12U] = ws121;
+  ws34[13U] = ws131;
+  ws34[14U] = ws141;
+  ws34[15U] = ws151;
+  ws34[16U] = ws161;
+  ws34[17U] = ws171;
+  ws34[18U] = ws181;
+  ws34[19U] = ws191;
+  ws34[20U] = ws201;
+  ws34[21U] = ws213;
+  ws34[22U] = ws221;
+  ws34[23U] = ws231;
+  ws34[24U] = ws241;
+  ws34[25U] = ws251;
+  ws34[26U] = ws261;
+  ws34[27U] = ws271;
+  ws34[28U] = ws281;
+  ws34[29U] = ws291;
+  ws34[30U] = ws301;
+  ws34[31U] = ws311;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws34[i]);
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____17 = s[i + 0U];
+      Lib_IntVector_Intrinsics_vec256 uu____18 = s[i + 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____19 = s[i + 10U];
+      _C[i] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____17,
+          Lib_IntVector_Intrinsics_vec256_xor(uu____18,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____19,
+              Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____20 = _C[(i1 + 4U) % 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____21 = _C[(i1 + 1U) % 5U];
+      Lib_IntVector_Intrinsics_vec256
+      _D =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____20,
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____21,
+              1U),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____21, 63U)));
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        s[i1 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i1 + 5U * i], _D);););
+    Lib_IntVector_Intrinsics_vec256 x = s[1U];
+    Lib_IntVector_Intrinsics_vec256 current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+      Lib_IntVector_Intrinsics_vec256 uu____22 = current;
+      s[_Y] =
+        Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____22, r),
+          Lib_IntVector_Intrinsics_vec256_shift_right64(uu____22, 64U - r));
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____23 = s[0U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____24 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v0 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____23,
+          Lib_IntVector_Intrinsics_vec256_and(uu____24, s[2U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____25 = s[1U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____26 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v1 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____25,
+          Lib_IntVector_Intrinsics_vec256_and(uu____26, s[3U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____27 = s[2U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____28 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v2 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____27,
+          Lib_IntVector_Intrinsics_vec256_and(uu____28, s[4U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____29 = s[3U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____30 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v3 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____29,
+          Lib_IntVector_Intrinsics_vec256_and(uu____30, s[0U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____31 = s[4U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____32 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v4 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____31,
+          Lib_IntVector_Intrinsics_vec256_and(uu____32, s[1U + 5U * i]));
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    Lib_IntVector_Intrinsics_vec256 uu____33 = s[0U];
+    s[0U] =
+      Lib_IntVector_Intrinsics_vec256_xor(uu____33,
+        Lib_IntVector_Intrinsics_vec256_load64(c));
+  }
+  for (uint32_t i0 = 0U; i0 < outputByteLen / rateInBytes; i0++)
+  {
+    uint8_t hbuf[1024U] = { 0U };
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+    Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256
+    v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+    Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256
+    v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+    Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256
+    v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+    Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256
+    v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+    Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256
+    v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+    Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256
+    v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+    Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256
+    v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256
+    v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+    }
+    for (uint32_t i = 0U; i < rateInBytes / 32U; i++)
+    {
+      uint8_t *b31 = rb.snd.snd.snd;
+      uint8_t *b21 = rb.snd.snd.fst;
+      uint8_t *b11 = rb.snd.fst;
+      uint8_t *b01 = rb.fst;
+      memcpy(b01 + i0 * rateInBytes + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+      memcpy(b11 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+      memcpy(b21 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+      memcpy(b31 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+    }
+    uint32_t rem0 = rateInBytes % 32U;
+    uint32_t j = rateInBytes / 32U;
+    uint8_t *b31 = rb.snd.snd.snd;
+    uint8_t *b21 = rb.snd.snd.fst;
+    uint8_t *b11 = rb.snd.fst;
+    uint8_t *b01 = rb.fst;
+    memcpy(b01 + i0 * rateInBytes + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+    memcpy(b11 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+    memcpy(b21 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+    memcpy(b31 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____34 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____35 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____36 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____34,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____35,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____36,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____37 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____38 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____37,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____38,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____38, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____39 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____39,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____39, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____40 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____41 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v023 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____40,
+            Lib_IntVector_Intrinsics_vec256_and(uu____41, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____42 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____43 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v123 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____42,
+            Lib_IntVector_Intrinsics_vec256_and(uu____43, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____44 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____45 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v223 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____44,
+            Lib_IntVector_Intrinsics_vec256_and(uu____45, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____46 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____47 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v323 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____46,
+            Lib_IntVector_Intrinsics_vec256_and(uu____47, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____48 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____49 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____48,
+            Lib_IntVector_Intrinsics_vec256_and(uu____49, s[1U + 5U * i]));
+        s[0U + 5U * i] = v023;
+        s[1U + 5U * i] = v123;
+        s[2U + 5U * i] = v223;
+        s[3U + 5U * i] = v323;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____50 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____50,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t remOut = outputByteLen % rateInBytes;
+  uint8_t hbuf[1024U] = { 0U };
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+  memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+  Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+  Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+  Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+  Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256
+  v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+  Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+  Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+  Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+  Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+  Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+  Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+  Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256
+  v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+  Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+  Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+  Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+  Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+  Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+  Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+  Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256
+  v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+  Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+  Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+  Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+  Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+  Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+  Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+  Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256
+  v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+  Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+  Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+  Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+  Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+  Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+  Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+  Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256
+  v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+  Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+  Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+  Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+  Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+  Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+  Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+  Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256
+  v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+  Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+  Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+  Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+  Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+  Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+  Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+  Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256
+  v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+  Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+  Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+  Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+  Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+  Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+  Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+  Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256
+  v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+  Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+  Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+  Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+  ws[0U] = ws0;
+  ws[1U] = ws1;
+  ws[2U] = ws2;
+  ws[3U] = ws3;
+  ws[4U] = ws4;
+  ws[5U] = ws5;
+  ws[6U] = ws6;
+  ws[7U] = ws7;
+  ws[8U] = ws8;
+  ws[9U] = ws9;
+  ws[10U] = ws10;
+  ws[11U] = ws11;
+  ws[12U] = ws12;
+  ws[13U] = ws13;
+  ws[14U] = ws14;
+  ws[15U] = ws15;
+  ws[16U] = ws16;
+  ws[17U] = ws17;
+  ws[18U] = ws18;
+  ws[19U] = ws19;
+  ws[20U] = ws20;
+  ws[21U] = ws21;
+  ws[22U] = ws22;
+  ws[23U] = ws23;
+  ws[24U] = ws24;
+  ws[25U] = ws25;
+  ws[26U] = ws26;
+  ws[27U] = ws27;
+  ws[28U] = ws28;
+  ws[29U] = ws29;
+  ws[30U] = ws30;
+  ws[31U] = ws31;
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+  }
+  for (uint32_t i = 0U; i < remOut / 32U; i++)
+  {
+    uint8_t *b3 = rb.snd.snd.snd;
+    uint8_t *b2 = rb.snd.snd.fst;
+    uint8_t *b1 = rb.snd.fst;
+    uint8_t *b0 = rb.fst;
+    memcpy(b0 + outputByteLen - remOut + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+    memcpy(b1 + outputByteLen - remOut + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+    memcpy(b2 + outputByteLen - remOut + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+    memcpy(b3 + outputByteLen - remOut + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+  }
+  uint32_t rem0 = remOut % 32U;
+  uint32_t j = remOut / 32U;
+  uint8_t *b3 = rb.snd.snd.snd;
+  uint8_t *b2 = rb.snd.snd.fst;
+  uint8_t *b1 = rb.snd.fst;
+  uint8_t *b0 = rb.fst;
+  memcpy(b0 + outputByteLen - remOut + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+  memcpy(b1 + outputByteLen - remOut + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+  memcpy(b2 + outputByteLen - remOut + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+  memcpy(b3 + outputByteLen - remOut + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+}
+
+void
+Hacl_Hash_SHA3_Simd256_shake256(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint32_t outputByteLen,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+)
+{
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  rb = { .fst = output0, .snd = { .fst = output1, .snd = { .fst = output2, .snd = output3 } } };
+  uint32_t rateInBytes = 136U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 s[25U] KRML_POST_ALIGN(32) = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b00[256U] = { 0U };
+    uint8_t b10[256U] = { 0U };
+    uint8_t b20[256U] = { 0U };
+    uint8_t b30[256U] = { 0U };
+    K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+    b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+    uint8_t *b31 = ib.snd.snd.snd;
+    uint8_t *b21 = ib.snd.snd.fst;
+    uint8_t *b11 = ib.snd.fst;
+    uint8_t *b01 = ib.fst;
+    uint8_t *bl3 = b_.snd.snd.snd;
+    uint8_t *bl2 = b_.snd.snd.fst;
+    uint8_t *bl1 = b_.snd.fst;
+    uint8_t *bl0 = b_.fst;
+    memcpy(bl0, b01 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl1, b11 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl2, b21 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl3, b31 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    uint8_t *b3 = b_.snd.snd.snd;
+    uint8_t *b2 = b_.snd.snd.fst;
+    uint8_t *b1 = b_.snd.fst;
+    uint8_t *b0 = b_.fst;
+    ws[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0);
+    ws[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1);
+    ws[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2);
+    ws[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3);
+    ws[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 32U);
+    ws[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 32U);
+    ws[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 32U);
+    ws[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 32U);
+    ws[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 64U);
+    ws[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 64U);
+    ws[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 64U);
+    ws[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 64U);
+    ws[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 96U);
+    ws[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 96U);
+    ws[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 96U);
+    ws[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 96U);
+    ws[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 128U);
+    ws[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 128U);
+    ws[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 128U);
+    ws[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 128U);
+    ws[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 160U);
+    ws[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 160U);
+    ws[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 160U);
+    ws[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 160U);
+    ws[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 192U);
+    ws[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 192U);
+    ws[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 192U);
+    ws[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 192U);
+    ws[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 224U);
+    ws[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 224U);
+    ws[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 224U);
+    ws[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 224U);
+    Lib_IntVector_Intrinsics_vec256 v00 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v10 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v20 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v30 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256
+    v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__;
+    Lib_IntVector_Intrinsics_vec256 v01 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v11 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v21 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v31 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256
+    v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__0;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__0;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__0;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__0;
+    Lib_IntVector_Intrinsics_vec256 v02 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v12 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v22 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v32 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256
+    v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__1;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__1;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__1;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__1;
+    Lib_IntVector_Intrinsics_vec256 v03 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v13 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v23 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v33 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256
+    v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__2;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__2;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__2;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__2;
+    Lib_IntVector_Intrinsics_vec256 v04 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v14 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v24 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v34 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256
+    v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__3;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__3;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__3;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__3;
+    Lib_IntVector_Intrinsics_vec256 v05 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v15 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v25 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v35 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256
+    v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__4;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__4;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__4;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__4;
+    Lib_IntVector_Intrinsics_vec256 v06 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v16 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v26 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v36 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256
+    v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__5;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__5;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__5;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__5;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256
+    v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__6;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__6;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__6;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__6;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws[i]);
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____0 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____1 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____2 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____0,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____1,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____2,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____3 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____4 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____3,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____4,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____4, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____5 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____5,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____5, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____6 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____7 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v07 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____6,
+            Lib_IntVector_Intrinsics_vec256_and(uu____7, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____8 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____9 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v17 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____8,
+            Lib_IntVector_Intrinsics_vec256_and(uu____9, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____10 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____11 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v27 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____10,
+            Lib_IntVector_Intrinsics_vec256_and(uu____11, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____12 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____13 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v37 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____12,
+            Lib_IntVector_Intrinsics_vec256_and(uu____13, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____14 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____15 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____14,
+            Lib_IntVector_Intrinsics_vec256_and(uu____15, s[1U + 5U * i]));
+        s[0U + 5U * i] = v07;
+        s[1U + 5U * i] = v17;
+        s[2U + 5U * i] = v27;
+        s[3U + 5U * i] = v37;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____16 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____16,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b00[256U] = { 0U };
+  uint8_t b10[256U] = { 0U };
+  uint8_t b20[256U] = { 0U };
+  uint8_t b30[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b32 = ib.snd.snd.snd;
+  uint8_t *b22 = ib.snd.snd.fst;
+  uint8_t *b12 = ib.snd.fst;
+  uint8_t *b02 = ib.fst;
+  uint8_t *bl3 = b_.snd.snd.snd;
+  uint8_t *bl2 = b_.snd.snd.fst;
+  uint8_t *bl1 = b_.snd.fst;
+  uint8_t *bl0 = b_.fst;
+  memcpy(bl0, b02 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl1, b12 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl2, b22 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl3, b32 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b33 = b_.snd.snd.snd;
+  uint8_t *b23 = b_.snd.snd.fst;
+  uint8_t *b13 = b_.snd.fst;
+  uint8_t *b03 = b_.fst;
+  b03[rem] = 0x1FU;
+  b13[rem] = 0x1FU;
+  b23[rem] = 0x1FU;
+  b33[rem] = 0x1FU;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws32[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b34 = b_.snd.snd.snd;
+  uint8_t *b24 = b_.snd.snd.fst;
+  uint8_t *b14 = b_.snd.fst;
+  uint8_t *b04 = b_.fst;
+  ws32[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04);
+  ws32[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14);
+  ws32[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24);
+  ws32[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34);
+  ws32[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 32U);
+  ws32[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 32U);
+  ws32[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 32U);
+  ws32[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 32U);
+  ws32[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 64U);
+  ws32[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 64U);
+  ws32[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 64U);
+  ws32[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 64U);
+  ws32[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 96U);
+  ws32[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 96U);
+  ws32[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 96U);
+  ws32[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 96U);
+  ws32[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 128U);
+  ws32[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 128U);
+  ws32[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 128U);
+  ws32[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 128U);
+  ws32[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 160U);
+  ws32[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 160U);
+  ws32[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 160U);
+  ws32[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 160U);
+  ws32[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 192U);
+  ws32[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 192U);
+  ws32[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 192U);
+  ws32[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 192U);
+  ws32[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 224U);
+  ws32[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 224U);
+  ws32[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 224U);
+  ws32[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v00 = ws32[0U];
+  Lib_IntVector_Intrinsics_vec256 v10 = ws32[1U];
+  Lib_IntVector_Intrinsics_vec256 v20 = ws32[2U];
+  Lib_IntVector_Intrinsics_vec256 v30 = ws32[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256
+  v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256 ws00 = v0__;
+  Lib_IntVector_Intrinsics_vec256 ws110 = v2__;
+  Lib_IntVector_Intrinsics_vec256 ws210 = v1__;
+  Lib_IntVector_Intrinsics_vec256 ws33 = v3__;
+  Lib_IntVector_Intrinsics_vec256 v01 = ws32[4U];
+  Lib_IntVector_Intrinsics_vec256 v11 = ws32[5U];
+  Lib_IntVector_Intrinsics_vec256 v21 = ws32[6U];
+  Lib_IntVector_Intrinsics_vec256 v31 = ws32[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256
+  v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256 ws40 = v0__0;
+  Lib_IntVector_Intrinsics_vec256 ws50 = v2__0;
+  Lib_IntVector_Intrinsics_vec256 ws60 = v1__0;
+  Lib_IntVector_Intrinsics_vec256 ws70 = v3__0;
+  Lib_IntVector_Intrinsics_vec256 v02 = ws32[8U];
+  Lib_IntVector_Intrinsics_vec256 v12 = ws32[9U];
+  Lib_IntVector_Intrinsics_vec256 v22 = ws32[10U];
+  Lib_IntVector_Intrinsics_vec256 v32 = ws32[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256
+  v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256 ws80 = v0__1;
+  Lib_IntVector_Intrinsics_vec256 ws90 = v2__1;
+  Lib_IntVector_Intrinsics_vec256 ws100 = v1__1;
+  Lib_IntVector_Intrinsics_vec256 ws111 = v3__1;
+  Lib_IntVector_Intrinsics_vec256 v03 = ws32[12U];
+  Lib_IntVector_Intrinsics_vec256 v13 = ws32[13U];
+  Lib_IntVector_Intrinsics_vec256 v23 = ws32[14U];
+  Lib_IntVector_Intrinsics_vec256 v33 = ws32[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256
+  v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256 ws120 = v0__2;
+  Lib_IntVector_Intrinsics_vec256 ws130 = v2__2;
+  Lib_IntVector_Intrinsics_vec256 ws140 = v1__2;
+  Lib_IntVector_Intrinsics_vec256 ws150 = v3__2;
+  Lib_IntVector_Intrinsics_vec256 v04 = ws32[16U];
+  Lib_IntVector_Intrinsics_vec256 v14 = ws32[17U];
+  Lib_IntVector_Intrinsics_vec256 v24 = ws32[18U];
+  Lib_IntVector_Intrinsics_vec256 v34 = ws32[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256
+  v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256 ws160 = v0__3;
+  Lib_IntVector_Intrinsics_vec256 ws170 = v2__3;
+  Lib_IntVector_Intrinsics_vec256 ws180 = v1__3;
+  Lib_IntVector_Intrinsics_vec256 ws190 = v3__3;
+  Lib_IntVector_Intrinsics_vec256 v05 = ws32[20U];
+  Lib_IntVector_Intrinsics_vec256 v15 = ws32[21U];
+  Lib_IntVector_Intrinsics_vec256 v25 = ws32[22U];
+  Lib_IntVector_Intrinsics_vec256 v35 = ws32[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256
+  v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256 ws200 = v0__4;
+  Lib_IntVector_Intrinsics_vec256 ws211 = v2__4;
+  Lib_IntVector_Intrinsics_vec256 ws220 = v1__4;
+  Lib_IntVector_Intrinsics_vec256 ws230 = v3__4;
+  Lib_IntVector_Intrinsics_vec256 v06 = ws32[24U];
+  Lib_IntVector_Intrinsics_vec256 v16 = ws32[25U];
+  Lib_IntVector_Intrinsics_vec256 v26 = ws32[26U];
+  Lib_IntVector_Intrinsics_vec256 v36 = ws32[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256
+  v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256 ws240 = v0__5;
+  Lib_IntVector_Intrinsics_vec256 ws250 = v2__5;
+  Lib_IntVector_Intrinsics_vec256 ws260 = v1__5;
+  Lib_IntVector_Intrinsics_vec256 ws270 = v3__5;
+  Lib_IntVector_Intrinsics_vec256 v07 = ws32[28U];
+  Lib_IntVector_Intrinsics_vec256 v17 = ws32[29U];
+  Lib_IntVector_Intrinsics_vec256 v27 = ws32[30U];
+  Lib_IntVector_Intrinsics_vec256 v37 = ws32[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256
+  v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256 ws280 = v0__6;
+  Lib_IntVector_Intrinsics_vec256 ws290 = v2__6;
+  Lib_IntVector_Intrinsics_vec256 ws300 = v1__6;
+  Lib_IntVector_Intrinsics_vec256 ws310 = v3__6;
+  ws32[0U] = ws00;
+  ws32[1U] = ws110;
+  ws32[2U] = ws210;
+  ws32[3U] = ws33;
+  ws32[4U] = ws40;
+  ws32[5U] = ws50;
+  ws32[6U] = ws60;
+  ws32[7U] = ws70;
+  ws32[8U] = ws80;
+  ws32[9U] = ws90;
+  ws32[10U] = ws100;
+  ws32[11U] = ws111;
+  ws32[12U] = ws120;
+  ws32[13U] = ws130;
+  ws32[14U] = ws140;
+  ws32[15U] = ws150;
+  ws32[16U] = ws160;
+  ws32[17U] = ws170;
+  ws32[18U] = ws180;
+  ws32[19U] = ws190;
+  ws32[20U] = ws200;
+  ws32[21U] = ws211;
+  ws32[22U] = ws220;
+  ws32[23U] = ws230;
+  ws32[24U] = ws240;
+  ws32[25U] = ws250;
+  ws32[26U] = ws260;
+  ws32[27U] = ws270;
+  ws32[28U] = ws280;
+  ws32[29U] = ws290;
+  ws32[30U] = ws300;
+  ws32[31U] = ws310;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws32[i]);
+  }
+  uint8_t b05[256U] = { 0U };
+  uint8_t b15[256U] = { 0U };
+  uint8_t b25[256U] = { 0U };
+  uint8_t b35[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b = { .fst = b05, .snd = { .fst = b15, .snd = { .fst = b25, .snd = b35 } } };
+  uint8_t *b36 = b.snd.snd.snd;
+  uint8_t *b26 = b.snd.snd.fst;
+  uint8_t *b16 = b.snd.fst;
+  uint8_t *b06 = b.fst;
+  b06[rateInBytes - 1U] = 0x80U;
+  b16[rateInBytes - 1U] = 0x80U;
+  b26[rateInBytes - 1U] = 0x80U;
+  b36[rateInBytes - 1U] = 0x80U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws34[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b37 = b.snd.snd.snd;
+  uint8_t *b27 = b.snd.snd.fst;
+  uint8_t *b17 = b.snd.fst;
+  uint8_t *b07 = b.fst;
+  ws34[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07);
+  ws34[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17);
+  ws34[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27);
+  ws34[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37);
+  ws34[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 32U);
+  ws34[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 32U);
+  ws34[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 32U);
+  ws34[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 32U);
+  ws34[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 64U);
+  ws34[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 64U);
+  ws34[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 64U);
+  ws34[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 64U);
+  ws34[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 96U);
+  ws34[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 96U);
+  ws34[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 96U);
+  ws34[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 96U);
+  ws34[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 128U);
+  ws34[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 128U);
+  ws34[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 128U);
+  ws34[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 128U);
+  ws34[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 160U);
+  ws34[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 160U);
+  ws34[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 160U);
+  ws34[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 160U);
+  ws34[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 192U);
+  ws34[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 192U);
+  ws34[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 192U);
+  ws34[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 192U);
+  ws34[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 224U);
+  ws34[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 224U);
+  ws34[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 224U);
+  ws34[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v08 = ws34[0U];
+  Lib_IntVector_Intrinsics_vec256 v18 = ws34[1U];
+  Lib_IntVector_Intrinsics_vec256 v28 = ws34[2U];
+  Lib_IntVector_Intrinsics_vec256 v38 = ws34[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v1_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v2_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v3_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v0__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v1__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v2__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256
+  v3__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256 ws01 = v0__7;
+  Lib_IntVector_Intrinsics_vec256 ws112 = v2__7;
+  Lib_IntVector_Intrinsics_vec256 ws212 = v1__7;
+  Lib_IntVector_Intrinsics_vec256 ws35 = v3__7;
+  Lib_IntVector_Intrinsics_vec256 v09 = ws34[4U];
+  Lib_IntVector_Intrinsics_vec256 v19 = ws34[5U];
+  Lib_IntVector_Intrinsics_vec256 v29 = ws34[6U];
+  Lib_IntVector_Intrinsics_vec256 v39 = ws34[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v1_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v2_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v3_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v0__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v1__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v2__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256
+  v3__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256 ws41 = v0__8;
+  Lib_IntVector_Intrinsics_vec256 ws51 = v2__8;
+  Lib_IntVector_Intrinsics_vec256 ws61 = v1__8;
+  Lib_IntVector_Intrinsics_vec256 ws71 = v3__8;
+  Lib_IntVector_Intrinsics_vec256 v010 = ws34[8U];
+  Lib_IntVector_Intrinsics_vec256 v110 = ws34[9U];
+  Lib_IntVector_Intrinsics_vec256 v210 = ws34[10U];
+  Lib_IntVector_Intrinsics_vec256 v310 = ws34[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v1_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v2_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v3_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v0__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v1__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v2__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256
+  v3__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256 ws81 = v0__9;
+  Lib_IntVector_Intrinsics_vec256 ws91 = v2__9;
+  Lib_IntVector_Intrinsics_vec256 ws101 = v1__9;
+  Lib_IntVector_Intrinsics_vec256 ws113 = v3__9;
+  Lib_IntVector_Intrinsics_vec256 v011 = ws34[12U];
+  Lib_IntVector_Intrinsics_vec256 v111 = ws34[13U];
+  Lib_IntVector_Intrinsics_vec256 v211 = ws34[14U];
+  Lib_IntVector_Intrinsics_vec256 v311 = ws34[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v1_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v2_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v3_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v0__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v1__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v2__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256
+  v3__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256 ws121 = v0__10;
+  Lib_IntVector_Intrinsics_vec256 ws131 = v2__10;
+  Lib_IntVector_Intrinsics_vec256 ws141 = v1__10;
+  Lib_IntVector_Intrinsics_vec256 ws151 = v3__10;
+  Lib_IntVector_Intrinsics_vec256 v012 = ws34[16U];
+  Lib_IntVector_Intrinsics_vec256 v112 = ws34[17U];
+  Lib_IntVector_Intrinsics_vec256 v212 = ws34[18U];
+  Lib_IntVector_Intrinsics_vec256 v312 = ws34[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v1_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v2_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v3_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v0__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v1__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v2__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256
+  v3__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256 ws161 = v0__11;
+  Lib_IntVector_Intrinsics_vec256 ws171 = v2__11;
+  Lib_IntVector_Intrinsics_vec256 ws181 = v1__11;
+  Lib_IntVector_Intrinsics_vec256 ws191 = v3__11;
+  Lib_IntVector_Intrinsics_vec256 v013 = ws34[20U];
+  Lib_IntVector_Intrinsics_vec256 v113 = ws34[21U];
+  Lib_IntVector_Intrinsics_vec256 v213 = ws34[22U];
+  Lib_IntVector_Intrinsics_vec256 v313 = ws34[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v1_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v2_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v3_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v0__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v1__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v2__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256
+  v3__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256 ws201 = v0__12;
+  Lib_IntVector_Intrinsics_vec256 ws213 = v2__12;
+  Lib_IntVector_Intrinsics_vec256 ws221 = v1__12;
+  Lib_IntVector_Intrinsics_vec256 ws231 = v3__12;
+  Lib_IntVector_Intrinsics_vec256 v014 = ws34[24U];
+  Lib_IntVector_Intrinsics_vec256 v114 = ws34[25U];
+  Lib_IntVector_Intrinsics_vec256 v214 = ws34[26U];
+  Lib_IntVector_Intrinsics_vec256 v314 = ws34[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v1_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v2_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v3_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v0__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v1__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v2__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256
+  v3__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256 ws241 = v0__13;
+  Lib_IntVector_Intrinsics_vec256 ws251 = v2__13;
+  Lib_IntVector_Intrinsics_vec256 ws261 = v1__13;
+  Lib_IntVector_Intrinsics_vec256 ws271 = v3__13;
+  Lib_IntVector_Intrinsics_vec256 v015 = ws34[28U];
+  Lib_IntVector_Intrinsics_vec256 v115 = ws34[29U];
+  Lib_IntVector_Intrinsics_vec256 v215 = ws34[30U];
+  Lib_IntVector_Intrinsics_vec256 v315 = ws34[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v1_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v2_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v3_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v0__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v1__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v2__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256
+  v3__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256 ws281 = v0__14;
+  Lib_IntVector_Intrinsics_vec256 ws291 = v2__14;
+  Lib_IntVector_Intrinsics_vec256 ws301 = v1__14;
+  Lib_IntVector_Intrinsics_vec256 ws311 = v3__14;
+  ws34[0U] = ws01;
+  ws34[1U] = ws112;
+  ws34[2U] = ws212;
+  ws34[3U] = ws35;
+  ws34[4U] = ws41;
+  ws34[5U] = ws51;
+  ws34[6U] = ws61;
+  ws34[7U] = ws71;
+  ws34[8U] = ws81;
+  ws34[9U] = ws91;
+  ws34[10U] = ws101;
+  ws34[11U] = ws113;
+  ws34[12U] = ws121;
+  ws34[13U] = ws131;
+  ws34[14U] = ws141;
+  ws34[15U] = ws151;
+  ws34[16U] = ws161;
+  ws34[17U] = ws171;
+  ws34[18U] = ws181;
+  ws34[19U] = ws191;
+  ws34[20U] = ws201;
+  ws34[21U] = ws213;
+  ws34[22U] = ws221;
+  ws34[23U] = ws231;
+  ws34[24U] = ws241;
+  ws34[25U] = ws251;
+  ws34[26U] = ws261;
+  ws34[27U] = ws271;
+  ws34[28U] = ws281;
+  ws34[29U] = ws291;
+  ws34[30U] = ws301;
+  ws34[31U] = ws311;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws34[i]);
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____17 = s[i + 0U];
+      Lib_IntVector_Intrinsics_vec256 uu____18 = s[i + 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____19 = s[i + 10U];
+      _C[i] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____17,
+          Lib_IntVector_Intrinsics_vec256_xor(uu____18,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____19,
+              Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____20 = _C[(i1 + 4U) % 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____21 = _C[(i1 + 1U) % 5U];
+      Lib_IntVector_Intrinsics_vec256
+      _D =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____20,
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____21,
+              1U),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____21, 63U)));
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        s[i1 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i1 + 5U * i], _D);););
+    Lib_IntVector_Intrinsics_vec256 x = s[1U];
+    Lib_IntVector_Intrinsics_vec256 current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+      Lib_IntVector_Intrinsics_vec256 uu____22 = current;
+      s[_Y] =
+        Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____22, r),
+          Lib_IntVector_Intrinsics_vec256_shift_right64(uu____22, 64U - r));
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____23 = s[0U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____24 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v0 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____23,
+          Lib_IntVector_Intrinsics_vec256_and(uu____24, s[2U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____25 = s[1U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____26 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v1 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____25,
+          Lib_IntVector_Intrinsics_vec256_and(uu____26, s[3U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____27 = s[2U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____28 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v2 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____27,
+          Lib_IntVector_Intrinsics_vec256_and(uu____28, s[4U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____29 = s[3U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____30 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v3 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____29,
+          Lib_IntVector_Intrinsics_vec256_and(uu____30, s[0U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____31 = s[4U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____32 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v4 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____31,
+          Lib_IntVector_Intrinsics_vec256_and(uu____32, s[1U + 5U * i]));
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    Lib_IntVector_Intrinsics_vec256 uu____33 = s[0U];
+    s[0U] =
+      Lib_IntVector_Intrinsics_vec256_xor(uu____33,
+        Lib_IntVector_Intrinsics_vec256_load64(c));
+  }
+  for (uint32_t i0 = 0U; i0 < outputByteLen / rateInBytes; i0++)
+  {
+    uint8_t hbuf[1024U] = { 0U };
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+    Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256
+    v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+    Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256
+    v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+    Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256
+    v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+    Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256
+    v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+    Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256
+    v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+    Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256
+    v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+    Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256
+    v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256
+    v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+    }
+    for (uint32_t i = 0U; i < rateInBytes / 32U; i++)
+    {
+      uint8_t *b31 = rb.snd.snd.snd;
+      uint8_t *b21 = rb.snd.snd.fst;
+      uint8_t *b11 = rb.snd.fst;
+      uint8_t *b01 = rb.fst;
+      memcpy(b01 + i0 * rateInBytes + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+      memcpy(b11 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+      memcpy(b21 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+      memcpy(b31 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+    }
+    uint32_t rem0 = rateInBytes % 32U;
+    uint32_t j = rateInBytes / 32U;
+    uint8_t *b31 = rb.snd.snd.snd;
+    uint8_t *b21 = rb.snd.snd.fst;
+    uint8_t *b11 = rb.snd.fst;
+    uint8_t *b01 = rb.fst;
+    memcpy(b01 + i0 * rateInBytes + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+    memcpy(b11 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+    memcpy(b21 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+    memcpy(b31 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____34 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____35 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____36 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____34,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____35,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____36,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____37 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____38 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____37,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____38,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____38, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____39 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____39,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____39, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____40 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____41 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v023 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____40,
+            Lib_IntVector_Intrinsics_vec256_and(uu____41, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____42 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____43 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v123 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____42,
+            Lib_IntVector_Intrinsics_vec256_and(uu____43, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____44 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____45 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v223 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____44,
+            Lib_IntVector_Intrinsics_vec256_and(uu____45, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____46 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____47 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v323 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____46,
+            Lib_IntVector_Intrinsics_vec256_and(uu____47, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____48 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____49 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____48,
+            Lib_IntVector_Intrinsics_vec256_and(uu____49, s[1U + 5U * i]));
+        s[0U + 5U * i] = v023;
+        s[1U + 5U * i] = v123;
+        s[2U + 5U * i] = v223;
+        s[3U + 5U * i] = v323;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____50 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____50,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t remOut = outputByteLen % rateInBytes;
+  uint8_t hbuf[1024U] = { 0U };
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+  memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+  Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+  Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+  Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+  Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256
+  v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+  Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+  Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+  Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+  Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+  Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+  Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+  Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256
+  v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+  Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+  Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+  Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+  Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+  Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+  Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+  Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256
+  v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+  Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+  Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+  Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+  Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+  Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+  Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+  Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256
+  v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+  Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+  Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+  Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+  Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+  Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+  Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+  Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256
+  v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+  Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+  Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+  Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+  Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+  Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+  Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+  Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256
+  v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+  Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+  Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+  Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+  Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+  Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+  Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+  Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256
+  v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+  Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+  Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+  Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+  Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+  Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+  Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+  Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256
+  v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+  Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+  Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+  Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+  ws[0U] = ws0;
+  ws[1U] = ws1;
+  ws[2U] = ws2;
+  ws[3U] = ws3;
+  ws[4U] = ws4;
+  ws[5U] = ws5;
+  ws[6U] = ws6;
+  ws[7U] = ws7;
+  ws[8U] = ws8;
+  ws[9U] = ws9;
+  ws[10U] = ws10;
+  ws[11U] = ws11;
+  ws[12U] = ws12;
+  ws[13U] = ws13;
+  ws[14U] = ws14;
+  ws[15U] = ws15;
+  ws[16U] = ws16;
+  ws[17U] = ws17;
+  ws[18U] = ws18;
+  ws[19U] = ws19;
+  ws[20U] = ws20;
+  ws[21U] = ws21;
+  ws[22U] = ws22;
+  ws[23U] = ws23;
+  ws[24U] = ws24;
+  ws[25U] = ws25;
+  ws[26U] = ws26;
+  ws[27U] = ws27;
+  ws[28U] = ws28;
+  ws[29U] = ws29;
+  ws[30U] = ws30;
+  ws[31U] = ws31;
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+  }
+  for (uint32_t i = 0U; i < remOut / 32U; i++)
+  {
+    uint8_t *b3 = rb.snd.snd.snd;
+    uint8_t *b2 = rb.snd.snd.fst;
+    uint8_t *b1 = rb.snd.fst;
+    uint8_t *b0 = rb.fst;
+    memcpy(b0 + outputByteLen - remOut + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+    memcpy(b1 + outputByteLen - remOut + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+    memcpy(b2 + outputByteLen - remOut + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+    memcpy(b3 + outputByteLen - remOut + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+  }
+  uint32_t rem0 = remOut % 32U;
+  uint32_t j = remOut / 32U;
+  uint8_t *b3 = rb.snd.snd.snd;
+  uint8_t *b2 = rb.snd.snd.fst;
+  uint8_t *b1 = rb.snd.fst;
+  uint8_t *b0 = rb.fst;
+  memcpy(b0 + outputByteLen - remOut + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+  memcpy(b1 + outputByteLen - remOut + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+  memcpy(b2 + outputByteLen - remOut + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+  memcpy(b3 + outputByteLen - remOut + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+}
+
+void
+Hacl_Hash_SHA3_Simd256_sha3_224(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+)
+{
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  rb = { .fst = output0, .snd = { .fst = output1, .snd = { .fst = output2, .snd = output3 } } };
+  uint32_t rateInBytes = 144U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 s[25U] KRML_POST_ALIGN(32) = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b00[256U] = { 0U };
+    uint8_t b10[256U] = { 0U };
+    uint8_t b20[256U] = { 0U };
+    uint8_t b30[256U] = { 0U };
+    K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+    b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+    uint8_t *b31 = ib.snd.snd.snd;
+    uint8_t *b21 = ib.snd.snd.fst;
+    uint8_t *b11 = ib.snd.fst;
+    uint8_t *b01 = ib.fst;
+    uint8_t *bl3 = b_.snd.snd.snd;
+    uint8_t *bl2 = b_.snd.snd.fst;
+    uint8_t *bl1 = b_.snd.fst;
+    uint8_t *bl0 = b_.fst;
+    memcpy(bl0, b01 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl1, b11 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl2, b21 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl3, b31 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    uint8_t *b3 = b_.snd.snd.snd;
+    uint8_t *b2 = b_.snd.snd.fst;
+    uint8_t *b1 = b_.snd.fst;
+    uint8_t *b0 = b_.fst;
+    ws[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0);
+    ws[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1);
+    ws[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2);
+    ws[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3);
+    ws[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 32U);
+    ws[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 32U);
+    ws[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 32U);
+    ws[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 32U);
+    ws[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 64U);
+    ws[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 64U);
+    ws[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 64U);
+    ws[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 64U);
+    ws[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 96U);
+    ws[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 96U);
+    ws[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 96U);
+    ws[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 96U);
+    ws[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 128U);
+    ws[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 128U);
+    ws[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 128U);
+    ws[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 128U);
+    ws[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 160U);
+    ws[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 160U);
+    ws[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 160U);
+    ws[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 160U);
+    ws[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 192U);
+    ws[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 192U);
+    ws[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 192U);
+    ws[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 192U);
+    ws[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 224U);
+    ws[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 224U);
+    ws[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 224U);
+    ws[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 224U);
+    Lib_IntVector_Intrinsics_vec256 v00 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v10 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v20 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v30 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256
+    v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__;
+    Lib_IntVector_Intrinsics_vec256 v01 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v11 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v21 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v31 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256
+    v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__0;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__0;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__0;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__0;
+    Lib_IntVector_Intrinsics_vec256 v02 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v12 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v22 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v32 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256
+    v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__1;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__1;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__1;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__1;
+    Lib_IntVector_Intrinsics_vec256 v03 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v13 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v23 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v33 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256
+    v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__2;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__2;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__2;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__2;
+    Lib_IntVector_Intrinsics_vec256 v04 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v14 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v24 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v34 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256
+    v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__3;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__3;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__3;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__3;
+    Lib_IntVector_Intrinsics_vec256 v05 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v15 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v25 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v35 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256
+    v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__4;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__4;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__4;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__4;
+    Lib_IntVector_Intrinsics_vec256 v06 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v16 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v26 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v36 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256
+    v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__5;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__5;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__5;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__5;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256
+    v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__6;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__6;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__6;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__6;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws[i]);
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____0 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____1 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____2 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____0,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____1,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____2,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____3 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____4 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____3,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____4,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____4, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____5 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____5,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____5, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____6 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____7 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v07 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____6,
+            Lib_IntVector_Intrinsics_vec256_and(uu____7, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____8 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____9 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v17 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____8,
+            Lib_IntVector_Intrinsics_vec256_and(uu____9, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____10 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____11 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v27 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____10,
+            Lib_IntVector_Intrinsics_vec256_and(uu____11, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____12 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____13 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v37 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____12,
+            Lib_IntVector_Intrinsics_vec256_and(uu____13, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____14 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____15 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____14,
+            Lib_IntVector_Intrinsics_vec256_and(uu____15, s[1U + 5U * i]));
+        s[0U + 5U * i] = v07;
+        s[1U + 5U * i] = v17;
+        s[2U + 5U * i] = v27;
+        s[3U + 5U * i] = v37;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____16 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____16,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b00[256U] = { 0U };
+  uint8_t b10[256U] = { 0U };
+  uint8_t b20[256U] = { 0U };
+  uint8_t b30[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b32 = ib.snd.snd.snd;
+  uint8_t *b22 = ib.snd.snd.fst;
+  uint8_t *b12 = ib.snd.fst;
+  uint8_t *b02 = ib.fst;
+  uint8_t *bl3 = b_.snd.snd.snd;
+  uint8_t *bl2 = b_.snd.snd.fst;
+  uint8_t *bl1 = b_.snd.fst;
+  uint8_t *bl0 = b_.fst;
+  memcpy(bl0, b02 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl1, b12 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl2, b22 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl3, b32 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b33 = b_.snd.snd.snd;
+  uint8_t *b23 = b_.snd.snd.fst;
+  uint8_t *b13 = b_.snd.fst;
+  uint8_t *b03 = b_.fst;
+  b03[rem] = 0x06U;
+  b13[rem] = 0x06U;
+  b23[rem] = 0x06U;
+  b33[rem] = 0x06U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws32[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b34 = b_.snd.snd.snd;
+  uint8_t *b24 = b_.snd.snd.fst;
+  uint8_t *b14 = b_.snd.fst;
+  uint8_t *b04 = b_.fst;
+  ws32[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04);
+  ws32[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14);
+  ws32[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24);
+  ws32[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34);
+  ws32[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 32U);
+  ws32[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 32U);
+  ws32[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 32U);
+  ws32[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 32U);
+  ws32[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 64U);
+  ws32[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 64U);
+  ws32[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 64U);
+  ws32[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 64U);
+  ws32[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 96U);
+  ws32[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 96U);
+  ws32[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 96U);
+  ws32[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 96U);
+  ws32[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 128U);
+  ws32[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 128U);
+  ws32[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 128U);
+  ws32[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 128U);
+  ws32[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 160U);
+  ws32[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 160U);
+  ws32[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 160U);
+  ws32[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 160U);
+  ws32[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 192U);
+  ws32[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 192U);
+  ws32[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 192U);
+  ws32[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 192U);
+  ws32[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 224U);
+  ws32[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 224U);
+  ws32[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 224U);
+  ws32[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v00 = ws32[0U];
+  Lib_IntVector_Intrinsics_vec256 v10 = ws32[1U];
+  Lib_IntVector_Intrinsics_vec256 v20 = ws32[2U];
+  Lib_IntVector_Intrinsics_vec256 v30 = ws32[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256
+  v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256 ws00 = v0__;
+  Lib_IntVector_Intrinsics_vec256 ws110 = v2__;
+  Lib_IntVector_Intrinsics_vec256 ws210 = v1__;
+  Lib_IntVector_Intrinsics_vec256 ws33 = v3__;
+  Lib_IntVector_Intrinsics_vec256 v01 = ws32[4U];
+  Lib_IntVector_Intrinsics_vec256 v11 = ws32[5U];
+  Lib_IntVector_Intrinsics_vec256 v21 = ws32[6U];
+  Lib_IntVector_Intrinsics_vec256 v31 = ws32[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256
+  v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256 ws40 = v0__0;
+  Lib_IntVector_Intrinsics_vec256 ws50 = v2__0;
+  Lib_IntVector_Intrinsics_vec256 ws60 = v1__0;
+  Lib_IntVector_Intrinsics_vec256 ws70 = v3__0;
+  Lib_IntVector_Intrinsics_vec256 v02 = ws32[8U];
+  Lib_IntVector_Intrinsics_vec256 v12 = ws32[9U];
+  Lib_IntVector_Intrinsics_vec256 v22 = ws32[10U];
+  Lib_IntVector_Intrinsics_vec256 v32 = ws32[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256
+  v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256 ws80 = v0__1;
+  Lib_IntVector_Intrinsics_vec256 ws90 = v2__1;
+  Lib_IntVector_Intrinsics_vec256 ws100 = v1__1;
+  Lib_IntVector_Intrinsics_vec256 ws111 = v3__1;
+  Lib_IntVector_Intrinsics_vec256 v03 = ws32[12U];
+  Lib_IntVector_Intrinsics_vec256 v13 = ws32[13U];
+  Lib_IntVector_Intrinsics_vec256 v23 = ws32[14U];
+  Lib_IntVector_Intrinsics_vec256 v33 = ws32[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256
+  v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256 ws120 = v0__2;
+  Lib_IntVector_Intrinsics_vec256 ws130 = v2__2;
+  Lib_IntVector_Intrinsics_vec256 ws140 = v1__2;
+  Lib_IntVector_Intrinsics_vec256 ws150 = v3__2;
+  Lib_IntVector_Intrinsics_vec256 v04 = ws32[16U];
+  Lib_IntVector_Intrinsics_vec256 v14 = ws32[17U];
+  Lib_IntVector_Intrinsics_vec256 v24 = ws32[18U];
+  Lib_IntVector_Intrinsics_vec256 v34 = ws32[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256
+  v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256 ws160 = v0__3;
+  Lib_IntVector_Intrinsics_vec256 ws170 = v2__3;
+  Lib_IntVector_Intrinsics_vec256 ws180 = v1__3;
+  Lib_IntVector_Intrinsics_vec256 ws190 = v3__3;
+  Lib_IntVector_Intrinsics_vec256 v05 = ws32[20U];
+  Lib_IntVector_Intrinsics_vec256 v15 = ws32[21U];
+  Lib_IntVector_Intrinsics_vec256 v25 = ws32[22U];
+  Lib_IntVector_Intrinsics_vec256 v35 = ws32[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256
+  v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256 ws200 = v0__4;
+  Lib_IntVector_Intrinsics_vec256 ws211 = v2__4;
+  Lib_IntVector_Intrinsics_vec256 ws220 = v1__4;
+  Lib_IntVector_Intrinsics_vec256 ws230 = v3__4;
+  Lib_IntVector_Intrinsics_vec256 v06 = ws32[24U];
+  Lib_IntVector_Intrinsics_vec256 v16 = ws32[25U];
+  Lib_IntVector_Intrinsics_vec256 v26 = ws32[26U];
+  Lib_IntVector_Intrinsics_vec256 v36 = ws32[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256
+  v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256 ws240 = v0__5;
+  Lib_IntVector_Intrinsics_vec256 ws250 = v2__5;
+  Lib_IntVector_Intrinsics_vec256 ws260 = v1__5;
+  Lib_IntVector_Intrinsics_vec256 ws270 = v3__5;
+  Lib_IntVector_Intrinsics_vec256 v07 = ws32[28U];
+  Lib_IntVector_Intrinsics_vec256 v17 = ws32[29U];
+  Lib_IntVector_Intrinsics_vec256 v27 = ws32[30U];
+  Lib_IntVector_Intrinsics_vec256 v37 = ws32[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256
+  v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256 ws280 = v0__6;
+  Lib_IntVector_Intrinsics_vec256 ws290 = v2__6;
+  Lib_IntVector_Intrinsics_vec256 ws300 = v1__6;
+  Lib_IntVector_Intrinsics_vec256 ws310 = v3__6;
+  ws32[0U] = ws00;
+  ws32[1U] = ws110;
+  ws32[2U] = ws210;
+  ws32[3U] = ws33;
+  ws32[4U] = ws40;
+  ws32[5U] = ws50;
+  ws32[6U] = ws60;
+  ws32[7U] = ws70;
+  ws32[8U] = ws80;
+  ws32[9U] = ws90;
+  ws32[10U] = ws100;
+  ws32[11U] = ws111;
+  ws32[12U] = ws120;
+  ws32[13U] = ws130;
+  ws32[14U] = ws140;
+  ws32[15U] = ws150;
+  ws32[16U] = ws160;
+  ws32[17U] = ws170;
+  ws32[18U] = ws180;
+  ws32[19U] = ws190;
+  ws32[20U] = ws200;
+  ws32[21U] = ws211;
+  ws32[22U] = ws220;
+  ws32[23U] = ws230;
+  ws32[24U] = ws240;
+  ws32[25U] = ws250;
+  ws32[26U] = ws260;
+  ws32[27U] = ws270;
+  ws32[28U] = ws280;
+  ws32[29U] = ws290;
+  ws32[30U] = ws300;
+  ws32[31U] = ws310;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws32[i]);
+  }
+  uint8_t b05[256U] = { 0U };
+  uint8_t b15[256U] = { 0U };
+  uint8_t b25[256U] = { 0U };
+  uint8_t b35[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b = { .fst = b05, .snd = { .fst = b15, .snd = { .fst = b25, .snd = b35 } } };
+  uint8_t *b36 = b.snd.snd.snd;
+  uint8_t *b26 = b.snd.snd.fst;
+  uint8_t *b16 = b.snd.fst;
+  uint8_t *b06 = b.fst;
+  b06[rateInBytes - 1U] = 0x80U;
+  b16[rateInBytes - 1U] = 0x80U;
+  b26[rateInBytes - 1U] = 0x80U;
+  b36[rateInBytes - 1U] = 0x80U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws34[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b37 = b.snd.snd.snd;
+  uint8_t *b27 = b.snd.snd.fst;
+  uint8_t *b17 = b.snd.fst;
+  uint8_t *b07 = b.fst;
+  ws34[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07);
+  ws34[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17);
+  ws34[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27);
+  ws34[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37);
+  ws34[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 32U);
+  ws34[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 32U);
+  ws34[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 32U);
+  ws34[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 32U);
+  ws34[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 64U);
+  ws34[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 64U);
+  ws34[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 64U);
+  ws34[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 64U);
+  ws34[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 96U);
+  ws34[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 96U);
+  ws34[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 96U);
+  ws34[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 96U);
+  ws34[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 128U);
+  ws34[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 128U);
+  ws34[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 128U);
+  ws34[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 128U);
+  ws34[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 160U);
+  ws34[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 160U);
+  ws34[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 160U);
+  ws34[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 160U);
+  ws34[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 192U);
+  ws34[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 192U);
+  ws34[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 192U);
+  ws34[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 192U);
+  ws34[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 224U);
+  ws34[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 224U);
+  ws34[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 224U);
+  ws34[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v08 = ws34[0U];
+  Lib_IntVector_Intrinsics_vec256 v18 = ws34[1U];
+  Lib_IntVector_Intrinsics_vec256 v28 = ws34[2U];
+  Lib_IntVector_Intrinsics_vec256 v38 = ws34[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v1_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v2_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v3_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v0__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v1__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v2__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256
+  v3__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256 ws01 = v0__7;
+  Lib_IntVector_Intrinsics_vec256 ws112 = v2__7;
+  Lib_IntVector_Intrinsics_vec256 ws212 = v1__7;
+  Lib_IntVector_Intrinsics_vec256 ws35 = v3__7;
+  Lib_IntVector_Intrinsics_vec256 v09 = ws34[4U];
+  Lib_IntVector_Intrinsics_vec256 v19 = ws34[5U];
+  Lib_IntVector_Intrinsics_vec256 v29 = ws34[6U];
+  Lib_IntVector_Intrinsics_vec256 v39 = ws34[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v1_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v2_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v3_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v0__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v1__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v2__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256
+  v3__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256 ws41 = v0__8;
+  Lib_IntVector_Intrinsics_vec256 ws51 = v2__8;
+  Lib_IntVector_Intrinsics_vec256 ws61 = v1__8;
+  Lib_IntVector_Intrinsics_vec256 ws71 = v3__8;
+  Lib_IntVector_Intrinsics_vec256 v010 = ws34[8U];
+  Lib_IntVector_Intrinsics_vec256 v110 = ws34[9U];
+  Lib_IntVector_Intrinsics_vec256 v210 = ws34[10U];
+  Lib_IntVector_Intrinsics_vec256 v310 = ws34[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v1_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v2_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v3_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v0__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v1__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v2__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256
+  v3__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256 ws81 = v0__9;
+  Lib_IntVector_Intrinsics_vec256 ws91 = v2__9;
+  Lib_IntVector_Intrinsics_vec256 ws101 = v1__9;
+  Lib_IntVector_Intrinsics_vec256 ws113 = v3__9;
+  Lib_IntVector_Intrinsics_vec256 v011 = ws34[12U];
+  Lib_IntVector_Intrinsics_vec256 v111 = ws34[13U];
+  Lib_IntVector_Intrinsics_vec256 v211 = ws34[14U];
+  Lib_IntVector_Intrinsics_vec256 v311 = ws34[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v1_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v2_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v3_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v0__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v1__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v2__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256
+  v3__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256 ws121 = v0__10;
+  Lib_IntVector_Intrinsics_vec256 ws131 = v2__10;
+  Lib_IntVector_Intrinsics_vec256 ws141 = v1__10;
+  Lib_IntVector_Intrinsics_vec256 ws151 = v3__10;
+  Lib_IntVector_Intrinsics_vec256 v012 = ws34[16U];
+  Lib_IntVector_Intrinsics_vec256 v112 = ws34[17U];
+  Lib_IntVector_Intrinsics_vec256 v212 = ws34[18U];
+  Lib_IntVector_Intrinsics_vec256 v312 = ws34[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v1_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v2_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v3_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v0__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v1__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v2__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256
+  v3__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256 ws161 = v0__11;
+  Lib_IntVector_Intrinsics_vec256 ws171 = v2__11;
+  Lib_IntVector_Intrinsics_vec256 ws181 = v1__11;
+  Lib_IntVector_Intrinsics_vec256 ws191 = v3__11;
+  Lib_IntVector_Intrinsics_vec256 v013 = ws34[20U];
+  Lib_IntVector_Intrinsics_vec256 v113 = ws34[21U];
+  Lib_IntVector_Intrinsics_vec256 v213 = ws34[22U];
+  Lib_IntVector_Intrinsics_vec256 v313 = ws34[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v1_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v2_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v3_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v0__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v1__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v2__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256
+  v3__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256 ws201 = v0__12;
+  Lib_IntVector_Intrinsics_vec256 ws213 = v2__12;
+  Lib_IntVector_Intrinsics_vec256 ws221 = v1__12;
+  Lib_IntVector_Intrinsics_vec256 ws231 = v3__12;
+  Lib_IntVector_Intrinsics_vec256 v014 = ws34[24U];
+  Lib_IntVector_Intrinsics_vec256 v114 = ws34[25U];
+  Lib_IntVector_Intrinsics_vec256 v214 = ws34[26U];
+  Lib_IntVector_Intrinsics_vec256 v314 = ws34[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v1_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v2_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v3_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v0__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v1__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v2__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256
+  v3__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256 ws241 = v0__13;
+  Lib_IntVector_Intrinsics_vec256 ws251 = v2__13;
+  Lib_IntVector_Intrinsics_vec256 ws261 = v1__13;
+  Lib_IntVector_Intrinsics_vec256 ws271 = v3__13;
+  Lib_IntVector_Intrinsics_vec256 v015 = ws34[28U];
+  Lib_IntVector_Intrinsics_vec256 v115 = ws34[29U];
+  Lib_IntVector_Intrinsics_vec256 v215 = ws34[30U];
+  Lib_IntVector_Intrinsics_vec256 v315 = ws34[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v1_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v2_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v3_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v0__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v1__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v2__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256
+  v3__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256 ws281 = v0__14;
+  Lib_IntVector_Intrinsics_vec256 ws291 = v2__14;
+  Lib_IntVector_Intrinsics_vec256 ws301 = v1__14;
+  Lib_IntVector_Intrinsics_vec256 ws311 = v3__14;
+  ws34[0U] = ws01;
+  ws34[1U] = ws112;
+  ws34[2U] = ws212;
+  ws34[3U] = ws35;
+  ws34[4U] = ws41;
+  ws34[5U] = ws51;
+  ws34[6U] = ws61;
+  ws34[7U] = ws71;
+  ws34[8U] = ws81;
+  ws34[9U] = ws91;
+  ws34[10U] = ws101;
+  ws34[11U] = ws113;
+  ws34[12U] = ws121;
+  ws34[13U] = ws131;
+  ws34[14U] = ws141;
+  ws34[15U] = ws151;
+  ws34[16U] = ws161;
+  ws34[17U] = ws171;
+  ws34[18U] = ws181;
+  ws34[19U] = ws191;
+  ws34[20U] = ws201;
+  ws34[21U] = ws213;
+  ws34[22U] = ws221;
+  ws34[23U] = ws231;
+  ws34[24U] = ws241;
+  ws34[25U] = ws251;
+  ws34[26U] = ws261;
+  ws34[27U] = ws271;
+  ws34[28U] = ws281;
+  ws34[29U] = ws291;
+  ws34[30U] = ws301;
+  ws34[31U] = ws311;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws34[i]);
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____17 = s[i + 0U];
+      Lib_IntVector_Intrinsics_vec256 uu____18 = s[i + 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____19 = s[i + 10U];
+      _C[i] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____17,
+          Lib_IntVector_Intrinsics_vec256_xor(uu____18,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____19,
+              Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____20 = _C[(i1 + 4U) % 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____21 = _C[(i1 + 1U) % 5U];
+      Lib_IntVector_Intrinsics_vec256
+      _D =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____20,
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____21,
+              1U),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____21, 63U)));
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        s[i1 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i1 + 5U * i], _D);););
+    Lib_IntVector_Intrinsics_vec256 x = s[1U];
+    Lib_IntVector_Intrinsics_vec256 current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+      Lib_IntVector_Intrinsics_vec256 uu____22 = current;
+      s[_Y] =
+        Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____22, r),
+          Lib_IntVector_Intrinsics_vec256_shift_right64(uu____22, 64U - r));
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____23 = s[0U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____24 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v0 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____23,
+          Lib_IntVector_Intrinsics_vec256_and(uu____24, s[2U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____25 = s[1U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____26 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v1 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____25,
+          Lib_IntVector_Intrinsics_vec256_and(uu____26, s[3U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____27 = s[2U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____28 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v2 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____27,
+          Lib_IntVector_Intrinsics_vec256_and(uu____28, s[4U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____29 = s[3U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____30 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v3 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____29,
+          Lib_IntVector_Intrinsics_vec256_and(uu____30, s[0U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____31 = s[4U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____32 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v4 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____31,
+          Lib_IntVector_Intrinsics_vec256_and(uu____32, s[1U + 5U * i]));
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    Lib_IntVector_Intrinsics_vec256 uu____33 = s[0U];
+    s[0U] =
+      Lib_IntVector_Intrinsics_vec256_xor(uu____33,
+        Lib_IntVector_Intrinsics_vec256_load64(c));
+  }
+  for (uint32_t i0 = 0U; i0 < 28U / rateInBytes; i0++)
+  {
+    uint8_t hbuf[1024U] = { 0U };
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+    Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256
+    v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+    Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256
+    v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+    Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256
+    v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+    Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256
+    v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+    Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256
+    v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+    Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256
+    v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+    Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256
+    v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256
+    v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+    }
+    for (uint32_t i = 0U; i < rateInBytes / 32U; i++)
+    {
+      uint8_t *b31 = rb.snd.snd.snd;
+      uint8_t *b21 = rb.snd.snd.fst;
+      uint8_t *b11 = rb.snd.fst;
+      uint8_t *b01 = rb.fst;
+      memcpy(b01 + i0 * rateInBytes + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+      memcpy(b11 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+      memcpy(b21 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+      memcpy(b31 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+    }
+    uint32_t rem0 = rateInBytes % 32U;
+    uint32_t j = rateInBytes / 32U;
+    uint8_t *b31 = rb.snd.snd.snd;
+    uint8_t *b21 = rb.snd.snd.fst;
+    uint8_t *b11 = rb.snd.fst;
+    uint8_t *b01 = rb.fst;
+    memcpy(b01 + i0 * rateInBytes + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+    memcpy(b11 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+    memcpy(b21 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+    memcpy(b31 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____34 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____35 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____36 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____34,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____35,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____36,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____37 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____38 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____37,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____38,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____38, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____39 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____39,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____39, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____40 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____41 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v023 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____40,
+            Lib_IntVector_Intrinsics_vec256_and(uu____41, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____42 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____43 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v123 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____42,
+            Lib_IntVector_Intrinsics_vec256_and(uu____43, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____44 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____45 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v223 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____44,
+            Lib_IntVector_Intrinsics_vec256_and(uu____45, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____46 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____47 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v323 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____46,
+            Lib_IntVector_Intrinsics_vec256_and(uu____47, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____48 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____49 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____48,
+            Lib_IntVector_Intrinsics_vec256_and(uu____49, s[1U + 5U * i]));
+        s[0U + 5U * i] = v023;
+        s[1U + 5U * i] = v123;
+        s[2U + 5U * i] = v223;
+        s[3U + 5U * i] = v323;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____50 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____50,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t remOut = 28U % rateInBytes;
+  uint8_t hbuf[1024U] = { 0U };
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+  memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+  Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+  Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+  Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+  Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256
+  v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+  Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+  Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+  Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+  Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+  Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+  Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+  Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256
+  v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+  Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+  Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+  Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+  Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+  Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+  Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+  Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256
+  v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+  Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+  Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+  Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+  Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+  Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+  Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+  Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256
+  v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+  Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+  Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+  Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+  Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+  Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+  Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+  Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256
+  v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+  Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+  Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+  Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+  Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+  Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+  Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+  Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256
+  v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+  Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+  Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+  Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+  Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+  Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+  Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+  Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256
+  v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+  Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+  Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+  Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+  Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+  Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+  Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+  Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256
+  v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+  Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+  Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+  Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+  ws[0U] = ws0;
+  ws[1U] = ws1;
+  ws[2U] = ws2;
+  ws[3U] = ws3;
+  ws[4U] = ws4;
+  ws[5U] = ws5;
+  ws[6U] = ws6;
+  ws[7U] = ws7;
+  ws[8U] = ws8;
+  ws[9U] = ws9;
+  ws[10U] = ws10;
+  ws[11U] = ws11;
+  ws[12U] = ws12;
+  ws[13U] = ws13;
+  ws[14U] = ws14;
+  ws[15U] = ws15;
+  ws[16U] = ws16;
+  ws[17U] = ws17;
+  ws[18U] = ws18;
+  ws[19U] = ws19;
+  ws[20U] = ws20;
+  ws[21U] = ws21;
+  ws[22U] = ws22;
+  ws[23U] = ws23;
+  ws[24U] = ws24;
+  ws[25U] = ws25;
+  ws[26U] = ws26;
+  ws[27U] = ws27;
+  ws[28U] = ws28;
+  ws[29U] = ws29;
+  ws[30U] = ws30;
+  ws[31U] = ws31;
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+  }
+  for (uint32_t i = 0U; i < remOut / 32U; i++)
+  {
+    uint8_t *b3 = rb.snd.snd.snd;
+    uint8_t *b2 = rb.snd.snd.fst;
+    uint8_t *b1 = rb.snd.fst;
+    uint8_t *b0 = rb.fst;
+    memcpy(b0 + 28U - remOut + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+    memcpy(b1 + 28U - remOut + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+    memcpy(b2 + 28U - remOut + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+    memcpy(b3 + 28U - remOut + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+  }
+  uint32_t rem0 = remOut % 32U;
+  uint32_t j = remOut / 32U;
+  uint8_t *b3 = rb.snd.snd.snd;
+  uint8_t *b2 = rb.snd.snd.fst;
+  uint8_t *b1 = rb.snd.fst;
+  uint8_t *b0 = rb.fst;
+  memcpy(b0 + 28U - remOut + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+  memcpy(b1 + 28U - remOut + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+  memcpy(b2 + 28U - remOut + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+  memcpy(b3 + 28U - remOut + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+}
+
+void
+Hacl_Hash_SHA3_Simd256_sha3_256(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+)
+{
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  rb = { .fst = output0, .snd = { .fst = output1, .snd = { .fst = output2, .snd = output3 } } };
+  uint32_t rateInBytes = 136U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 s[25U] KRML_POST_ALIGN(32) = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b00[256U] = { 0U };
+    uint8_t b10[256U] = { 0U };
+    uint8_t b20[256U] = { 0U };
+    uint8_t b30[256U] = { 0U };
+    K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+    b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+    uint8_t *b31 = ib.snd.snd.snd;
+    uint8_t *b21 = ib.snd.snd.fst;
+    uint8_t *b11 = ib.snd.fst;
+    uint8_t *b01 = ib.fst;
+    uint8_t *bl3 = b_.snd.snd.snd;
+    uint8_t *bl2 = b_.snd.snd.fst;
+    uint8_t *bl1 = b_.snd.fst;
+    uint8_t *bl0 = b_.fst;
+    memcpy(bl0, b01 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl1, b11 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl2, b21 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl3, b31 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    uint8_t *b3 = b_.snd.snd.snd;
+    uint8_t *b2 = b_.snd.snd.fst;
+    uint8_t *b1 = b_.snd.fst;
+    uint8_t *b0 = b_.fst;
+    ws[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0);
+    ws[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1);
+    ws[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2);
+    ws[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3);
+    ws[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 32U);
+    ws[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 32U);
+    ws[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 32U);
+    ws[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 32U);
+    ws[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 64U);
+    ws[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 64U);
+    ws[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 64U);
+    ws[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 64U);
+    ws[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 96U);
+    ws[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 96U);
+    ws[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 96U);
+    ws[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 96U);
+    ws[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 128U);
+    ws[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 128U);
+    ws[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 128U);
+    ws[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 128U);
+    ws[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 160U);
+    ws[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 160U);
+    ws[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 160U);
+    ws[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 160U);
+    ws[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 192U);
+    ws[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 192U);
+    ws[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 192U);
+    ws[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 192U);
+    ws[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 224U);
+    ws[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 224U);
+    ws[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 224U);
+    ws[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 224U);
+    Lib_IntVector_Intrinsics_vec256 v00 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v10 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v20 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v30 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256
+    v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__;
+    Lib_IntVector_Intrinsics_vec256 v01 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v11 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v21 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v31 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256
+    v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__0;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__0;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__0;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__0;
+    Lib_IntVector_Intrinsics_vec256 v02 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v12 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v22 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v32 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256
+    v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__1;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__1;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__1;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__1;
+    Lib_IntVector_Intrinsics_vec256 v03 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v13 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v23 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v33 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256
+    v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__2;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__2;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__2;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__2;
+    Lib_IntVector_Intrinsics_vec256 v04 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v14 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v24 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v34 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256
+    v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__3;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__3;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__3;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__3;
+    Lib_IntVector_Intrinsics_vec256 v05 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v15 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v25 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v35 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256
+    v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__4;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__4;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__4;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__4;
+    Lib_IntVector_Intrinsics_vec256 v06 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v16 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v26 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v36 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256
+    v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__5;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__5;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__5;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__5;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256
+    v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__6;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__6;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__6;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__6;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws[i]);
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____0 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____1 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____2 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____0,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____1,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____2,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____3 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____4 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____3,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____4,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____4, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____5 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____5,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____5, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____6 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____7 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v07 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____6,
+            Lib_IntVector_Intrinsics_vec256_and(uu____7, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____8 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____9 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v17 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____8,
+            Lib_IntVector_Intrinsics_vec256_and(uu____9, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____10 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____11 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v27 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____10,
+            Lib_IntVector_Intrinsics_vec256_and(uu____11, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____12 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____13 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v37 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____12,
+            Lib_IntVector_Intrinsics_vec256_and(uu____13, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____14 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____15 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____14,
+            Lib_IntVector_Intrinsics_vec256_and(uu____15, s[1U + 5U * i]));
+        s[0U + 5U * i] = v07;
+        s[1U + 5U * i] = v17;
+        s[2U + 5U * i] = v27;
+        s[3U + 5U * i] = v37;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____16 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____16,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b00[256U] = { 0U };
+  uint8_t b10[256U] = { 0U };
+  uint8_t b20[256U] = { 0U };
+  uint8_t b30[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b32 = ib.snd.snd.snd;
+  uint8_t *b22 = ib.snd.snd.fst;
+  uint8_t *b12 = ib.snd.fst;
+  uint8_t *b02 = ib.fst;
+  uint8_t *bl3 = b_.snd.snd.snd;
+  uint8_t *bl2 = b_.snd.snd.fst;
+  uint8_t *bl1 = b_.snd.fst;
+  uint8_t *bl0 = b_.fst;
+  memcpy(bl0, b02 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl1, b12 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl2, b22 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl3, b32 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b33 = b_.snd.snd.snd;
+  uint8_t *b23 = b_.snd.snd.fst;
+  uint8_t *b13 = b_.snd.fst;
+  uint8_t *b03 = b_.fst;
+  b03[rem] = 0x06U;
+  b13[rem] = 0x06U;
+  b23[rem] = 0x06U;
+  b33[rem] = 0x06U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws32[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b34 = b_.snd.snd.snd;
+  uint8_t *b24 = b_.snd.snd.fst;
+  uint8_t *b14 = b_.snd.fst;
+  uint8_t *b04 = b_.fst;
+  ws32[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04);
+  ws32[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14);
+  ws32[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24);
+  ws32[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34);
+  ws32[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 32U);
+  ws32[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 32U);
+  ws32[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 32U);
+  ws32[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 32U);
+  ws32[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 64U);
+  ws32[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 64U);
+  ws32[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 64U);
+  ws32[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 64U);
+  ws32[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 96U);
+  ws32[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 96U);
+  ws32[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 96U);
+  ws32[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 96U);
+  ws32[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 128U);
+  ws32[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 128U);
+  ws32[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 128U);
+  ws32[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 128U);
+  ws32[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 160U);
+  ws32[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 160U);
+  ws32[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 160U);
+  ws32[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 160U);
+  ws32[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 192U);
+  ws32[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 192U);
+  ws32[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 192U);
+  ws32[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 192U);
+  ws32[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 224U);
+  ws32[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 224U);
+  ws32[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 224U);
+  ws32[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v00 = ws32[0U];
+  Lib_IntVector_Intrinsics_vec256 v10 = ws32[1U];
+  Lib_IntVector_Intrinsics_vec256 v20 = ws32[2U];
+  Lib_IntVector_Intrinsics_vec256 v30 = ws32[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256
+  v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256 ws00 = v0__;
+  Lib_IntVector_Intrinsics_vec256 ws110 = v2__;
+  Lib_IntVector_Intrinsics_vec256 ws210 = v1__;
+  Lib_IntVector_Intrinsics_vec256 ws33 = v3__;
+  Lib_IntVector_Intrinsics_vec256 v01 = ws32[4U];
+  Lib_IntVector_Intrinsics_vec256 v11 = ws32[5U];
+  Lib_IntVector_Intrinsics_vec256 v21 = ws32[6U];
+  Lib_IntVector_Intrinsics_vec256 v31 = ws32[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256
+  v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256 ws40 = v0__0;
+  Lib_IntVector_Intrinsics_vec256 ws50 = v2__0;
+  Lib_IntVector_Intrinsics_vec256 ws60 = v1__0;
+  Lib_IntVector_Intrinsics_vec256 ws70 = v3__0;
+  Lib_IntVector_Intrinsics_vec256 v02 = ws32[8U];
+  Lib_IntVector_Intrinsics_vec256 v12 = ws32[9U];
+  Lib_IntVector_Intrinsics_vec256 v22 = ws32[10U];
+  Lib_IntVector_Intrinsics_vec256 v32 = ws32[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256
+  v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256 ws80 = v0__1;
+  Lib_IntVector_Intrinsics_vec256 ws90 = v2__1;
+  Lib_IntVector_Intrinsics_vec256 ws100 = v1__1;
+  Lib_IntVector_Intrinsics_vec256 ws111 = v3__1;
+  Lib_IntVector_Intrinsics_vec256 v03 = ws32[12U];
+  Lib_IntVector_Intrinsics_vec256 v13 = ws32[13U];
+  Lib_IntVector_Intrinsics_vec256 v23 = ws32[14U];
+  Lib_IntVector_Intrinsics_vec256 v33 = ws32[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256
+  v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256 ws120 = v0__2;
+  Lib_IntVector_Intrinsics_vec256 ws130 = v2__2;
+  Lib_IntVector_Intrinsics_vec256 ws140 = v1__2;
+  Lib_IntVector_Intrinsics_vec256 ws150 = v3__2;
+  Lib_IntVector_Intrinsics_vec256 v04 = ws32[16U];
+  Lib_IntVector_Intrinsics_vec256 v14 = ws32[17U];
+  Lib_IntVector_Intrinsics_vec256 v24 = ws32[18U];
+  Lib_IntVector_Intrinsics_vec256 v34 = ws32[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256
+  v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256 ws160 = v0__3;
+  Lib_IntVector_Intrinsics_vec256 ws170 = v2__3;
+  Lib_IntVector_Intrinsics_vec256 ws180 = v1__3;
+  Lib_IntVector_Intrinsics_vec256 ws190 = v3__3;
+  Lib_IntVector_Intrinsics_vec256 v05 = ws32[20U];
+  Lib_IntVector_Intrinsics_vec256 v15 = ws32[21U];
+  Lib_IntVector_Intrinsics_vec256 v25 = ws32[22U];
+  Lib_IntVector_Intrinsics_vec256 v35 = ws32[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256
+  v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256 ws200 = v0__4;
+  Lib_IntVector_Intrinsics_vec256 ws211 = v2__4;
+  Lib_IntVector_Intrinsics_vec256 ws220 = v1__4;
+  Lib_IntVector_Intrinsics_vec256 ws230 = v3__4;
+  Lib_IntVector_Intrinsics_vec256 v06 = ws32[24U];
+  Lib_IntVector_Intrinsics_vec256 v16 = ws32[25U];
+  Lib_IntVector_Intrinsics_vec256 v26 = ws32[26U];
+  Lib_IntVector_Intrinsics_vec256 v36 = ws32[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256
+  v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256 ws240 = v0__5;
+  Lib_IntVector_Intrinsics_vec256 ws250 = v2__5;
+  Lib_IntVector_Intrinsics_vec256 ws260 = v1__5;
+  Lib_IntVector_Intrinsics_vec256 ws270 = v3__5;
+  Lib_IntVector_Intrinsics_vec256 v07 = ws32[28U];
+  Lib_IntVector_Intrinsics_vec256 v17 = ws32[29U];
+  Lib_IntVector_Intrinsics_vec256 v27 = ws32[30U];
+  Lib_IntVector_Intrinsics_vec256 v37 = ws32[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256
+  v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256 ws280 = v0__6;
+  Lib_IntVector_Intrinsics_vec256 ws290 = v2__6;
+  Lib_IntVector_Intrinsics_vec256 ws300 = v1__6;
+  Lib_IntVector_Intrinsics_vec256 ws310 = v3__6;
+  ws32[0U] = ws00;
+  ws32[1U] = ws110;
+  ws32[2U] = ws210;
+  ws32[3U] = ws33;
+  ws32[4U] = ws40;
+  ws32[5U] = ws50;
+  ws32[6U] = ws60;
+  ws32[7U] = ws70;
+  ws32[8U] = ws80;
+  ws32[9U] = ws90;
+  ws32[10U] = ws100;
+  ws32[11U] = ws111;
+  ws32[12U] = ws120;
+  ws32[13U] = ws130;
+  ws32[14U] = ws140;
+  ws32[15U] = ws150;
+  ws32[16U] = ws160;
+  ws32[17U] = ws170;
+  ws32[18U] = ws180;
+  ws32[19U] = ws190;
+  ws32[20U] = ws200;
+  ws32[21U] = ws211;
+  ws32[22U] = ws220;
+  ws32[23U] = ws230;
+  ws32[24U] = ws240;
+  ws32[25U] = ws250;
+  ws32[26U] = ws260;
+  ws32[27U] = ws270;
+  ws32[28U] = ws280;
+  ws32[29U] = ws290;
+  ws32[30U] = ws300;
+  ws32[31U] = ws310;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws32[i]);
+  }
+  uint8_t b05[256U] = { 0U };
+  uint8_t b15[256U] = { 0U };
+  uint8_t b25[256U] = { 0U };
+  uint8_t b35[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b = { .fst = b05, .snd = { .fst = b15, .snd = { .fst = b25, .snd = b35 } } };
+  uint8_t *b36 = b.snd.snd.snd;
+  uint8_t *b26 = b.snd.snd.fst;
+  uint8_t *b16 = b.snd.fst;
+  uint8_t *b06 = b.fst;
+  b06[rateInBytes - 1U] = 0x80U;
+  b16[rateInBytes - 1U] = 0x80U;
+  b26[rateInBytes - 1U] = 0x80U;
+  b36[rateInBytes - 1U] = 0x80U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws34[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b37 = b.snd.snd.snd;
+  uint8_t *b27 = b.snd.snd.fst;
+  uint8_t *b17 = b.snd.fst;
+  uint8_t *b07 = b.fst;
+  ws34[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07);
+  ws34[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17);
+  ws34[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27);
+  ws34[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37);
+  ws34[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 32U);
+  ws34[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 32U);
+  ws34[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 32U);
+  ws34[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 32U);
+  ws34[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 64U);
+  ws34[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 64U);
+  ws34[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 64U);
+  ws34[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 64U);
+  ws34[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 96U);
+  ws34[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 96U);
+  ws34[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 96U);
+  ws34[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 96U);
+  ws34[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 128U);
+  ws34[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 128U);
+  ws34[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 128U);
+  ws34[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 128U);
+  ws34[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 160U);
+  ws34[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 160U);
+  ws34[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 160U);
+  ws34[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 160U);
+  ws34[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 192U);
+  ws34[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 192U);
+  ws34[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 192U);
+  ws34[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 192U);
+  ws34[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 224U);
+  ws34[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 224U);
+  ws34[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 224U);
+  ws34[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v08 = ws34[0U];
+  Lib_IntVector_Intrinsics_vec256 v18 = ws34[1U];
+  Lib_IntVector_Intrinsics_vec256 v28 = ws34[2U];
+  Lib_IntVector_Intrinsics_vec256 v38 = ws34[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v1_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v2_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v3_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v0__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v1__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v2__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256
+  v3__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256 ws01 = v0__7;
+  Lib_IntVector_Intrinsics_vec256 ws112 = v2__7;
+  Lib_IntVector_Intrinsics_vec256 ws212 = v1__7;
+  Lib_IntVector_Intrinsics_vec256 ws35 = v3__7;
+  Lib_IntVector_Intrinsics_vec256 v09 = ws34[4U];
+  Lib_IntVector_Intrinsics_vec256 v19 = ws34[5U];
+  Lib_IntVector_Intrinsics_vec256 v29 = ws34[6U];
+  Lib_IntVector_Intrinsics_vec256 v39 = ws34[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v1_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v2_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v3_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v0__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v1__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v2__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256
+  v3__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256 ws41 = v0__8;
+  Lib_IntVector_Intrinsics_vec256 ws51 = v2__8;
+  Lib_IntVector_Intrinsics_vec256 ws61 = v1__8;
+  Lib_IntVector_Intrinsics_vec256 ws71 = v3__8;
+  Lib_IntVector_Intrinsics_vec256 v010 = ws34[8U];
+  Lib_IntVector_Intrinsics_vec256 v110 = ws34[9U];
+  Lib_IntVector_Intrinsics_vec256 v210 = ws34[10U];
+  Lib_IntVector_Intrinsics_vec256 v310 = ws34[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v1_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v2_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v3_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v0__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v1__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v2__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256
+  v3__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256 ws81 = v0__9;
+  Lib_IntVector_Intrinsics_vec256 ws91 = v2__9;
+  Lib_IntVector_Intrinsics_vec256 ws101 = v1__9;
+  Lib_IntVector_Intrinsics_vec256 ws113 = v3__9;
+  Lib_IntVector_Intrinsics_vec256 v011 = ws34[12U];
+  Lib_IntVector_Intrinsics_vec256 v111 = ws34[13U];
+  Lib_IntVector_Intrinsics_vec256 v211 = ws34[14U];
+  Lib_IntVector_Intrinsics_vec256 v311 = ws34[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v1_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v2_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v3_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v0__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v1__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v2__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256
+  v3__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256 ws121 = v0__10;
+  Lib_IntVector_Intrinsics_vec256 ws131 = v2__10;
+  Lib_IntVector_Intrinsics_vec256 ws141 = v1__10;
+  Lib_IntVector_Intrinsics_vec256 ws151 = v3__10;
+  Lib_IntVector_Intrinsics_vec256 v012 = ws34[16U];
+  Lib_IntVector_Intrinsics_vec256 v112 = ws34[17U];
+  Lib_IntVector_Intrinsics_vec256 v212 = ws34[18U];
+  Lib_IntVector_Intrinsics_vec256 v312 = ws34[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v1_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v2_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v3_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v0__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v1__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v2__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256
+  v3__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256 ws161 = v0__11;
+  Lib_IntVector_Intrinsics_vec256 ws171 = v2__11;
+  Lib_IntVector_Intrinsics_vec256 ws181 = v1__11;
+  Lib_IntVector_Intrinsics_vec256 ws191 = v3__11;
+  Lib_IntVector_Intrinsics_vec256 v013 = ws34[20U];
+  Lib_IntVector_Intrinsics_vec256 v113 = ws34[21U];
+  Lib_IntVector_Intrinsics_vec256 v213 = ws34[22U];
+  Lib_IntVector_Intrinsics_vec256 v313 = ws34[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v1_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v2_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v3_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v0__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v1__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v2__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256
+  v3__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256 ws201 = v0__12;
+  Lib_IntVector_Intrinsics_vec256 ws213 = v2__12;
+  Lib_IntVector_Intrinsics_vec256 ws221 = v1__12;
+  Lib_IntVector_Intrinsics_vec256 ws231 = v3__12;
+  Lib_IntVector_Intrinsics_vec256 v014 = ws34[24U];
+  Lib_IntVector_Intrinsics_vec256 v114 = ws34[25U];
+  Lib_IntVector_Intrinsics_vec256 v214 = ws34[26U];
+  Lib_IntVector_Intrinsics_vec256 v314 = ws34[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v1_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v2_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v3_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v0__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v1__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v2__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256
+  v3__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256 ws241 = v0__13;
+  Lib_IntVector_Intrinsics_vec256 ws251 = v2__13;
+  Lib_IntVector_Intrinsics_vec256 ws261 = v1__13;
+  Lib_IntVector_Intrinsics_vec256 ws271 = v3__13;
+  Lib_IntVector_Intrinsics_vec256 v015 = ws34[28U];
+  Lib_IntVector_Intrinsics_vec256 v115 = ws34[29U];
+  Lib_IntVector_Intrinsics_vec256 v215 = ws34[30U];
+  Lib_IntVector_Intrinsics_vec256 v315 = ws34[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v1_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v2_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v3_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v0__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v1__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v2__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256
+  v3__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256 ws281 = v0__14;
+  Lib_IntVector_Intrinsics_vec256 ws291 = v2__14;
+  Lib_IntVector_Intrinsics_vec256 ws301 = v1__14;
+  Lib_IntVector_Intrinsics_vec256 ws311 = v3__14;
+  ws34[0U] = ws01;
+  ws34[1U] = ws112;
+  ws34[2U] = ws212;
+  ws34[3U] = ws35;
+  ws34[4U] = ws41;
+  ws34[5U] = ws51;
+  ws34[6U] = ws61;
+  ws34[7U] = ws71;
+  ws34[8U] = ws81;
+  ws34[9U] = ws91;
+  ws34[10U] = ws101;
+  ws34[11U] = ws113;
+  ws34[12U] = ws121;
+  ws34[13U] = ws131;
+  ws34[14U] = ws141;
+  ws34[15U] = ws151;
+  ws34[16U] = ws161;
+  ws34[17U] = ws171;
+  ws34[18U] = ws181;
+  ws34[19U] = ws191;
+  ws34[20U] = ws201;
+  ws34[21U] = ws213;
+  ws34[22U] = ws221;
+  ws34[23U] = ws231;
+  ws34[24U] = ws241;
+  ws34[25U] = ws251;
+  ws34[26U] = ws261;
+  ws34[27U] = ws271;
+  ws34[28U] = ws281;
+  ws34[29U] = ws291;
+  ws34[30U] = ws301;
+  ws34[31U] = ws311;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws34[i]);
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____17 = s[i + 0U];
+      Lib_IntVector_Intrinsics_vec256 uu____18 = s[i + 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____19 = s[i + 10U];
+      _C[i] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____17,
+          Lib_IntVector_Intrinsics_vec256_xor(uu____18,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____19,
+              Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____20 = _C[(i1 + 4U) % 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____21 = _C[(i1 + 1U) % 5U];
+      Lib_IntVector_Intrinsics_vec256
+      _D =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____20,
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____21,
+              1U),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____21, 63U)));
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        s[i1 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i1 + 5U * i], _D);););
+    Lib_IntVector_Intrinsics_vec256 x = s[1U];
+    Lib_IntVector_Intrinsics_vec256 current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+      Lib_IntVector_Intrinsics_vec256 uu____22 = current;
+      s[_Y] =
+        Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____22, r),
+          Lib_IntVector_Intrinsics_vec256_shift_right64(uu____22, 64U - r));
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____23 = s[0U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____24 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v0 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____23,
+          Lib_IntVector_Intrinsics_vec256_and(uu____24, s[2U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____25 = s[1U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____26 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v1 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____25,
+          Lib_IntVector_Intrinsics_vec256_and(uu____26, s[3U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____27 = s[2U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____28 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v2 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____27,
+          Lib_IntVector_Intrinsics_vec256_and(uu____28, s[4U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____29 = s[3U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____30 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v3 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____29,
+          Lib_IntVector_Intrinsics_vec256_and(uu____30, s[0U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____31 = s[4U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____32 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v4 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____31,
+          Lib_IntVector_Intrinsics_vec256_and(uu____32, s[1U + 5U * i]));
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    Lib_IntVector_Intrinsics_vec256 uu____33 = s[0U];
+    s[0U] =
+      Lib_IntVector_Intrinsics_vec256_xor(uu____33,
+        Lib_IntVector_Intrinsics_vec256_load64(c));
+  }
+  for (uint32_t i0 = 0U; i0 < 32U / rateInBytes; i0++)
+  {
+    uint8_t hbuf[1024U] = { 0U };
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+    Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256
+    v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+    Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256
+    v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+    Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256
+    v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+    Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256
+    v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+    Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256
+    v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+    Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256
+    v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+    Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256
+    v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256
+    v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+    }
+    for (uint32_t i = 0U; i < rateInBytes / 32U; i++)
+    {
+      uint8_t *b31 = rb.snd.snd.snd;
+      uint8_t *b21 = rb.snd.snd.fst;
+      uint8_t *b11 = rb.snd.fst;
+      uint8_t *b01 = rb.fst;
+      memcpy(b01 + i0 * rateInBytes + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+      memcpy(b11 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+      memcpy(b21 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+      memcpy(b31 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+    }
+    uint32_t rem0 = rateInBytes % 32U;
+    uint32_t j = rateInBytes / 32U;
+    uint8_t *b31 = rb.snd.snd.snd;
+    uint8_t *b21 = rb.snd.snd.fst;
+    uint8_t *b11 = rb.snd.fst;
+    uint8_t *b01 = rb.fst;
+    memcpy(b01 + i0 * rateInBytes + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+    memcpy(b11 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+    memcpy(b21 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+    memcpy(b31 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____34 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____35 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____36 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____34,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____35,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____36,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____37 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____38 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____37,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____38,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____38, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____39 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____39,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____39, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____40 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____41 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v023 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____40,
+            Lib_IntVector_Intrinsics_vec256_and(uu____41, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____42 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____43 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v123 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____42,
+            Lib_IntVector_Intrinsics_vec256_and(uu____43, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____44 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____45 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v223 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____44,
+            Lib_IntVector_Intrinsics_vec256_and(uu____45, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____46 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____47 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v323 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____46,
+            Lib_IntVector_Intrinsics_vec256_and(uu____47, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____48 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____49 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____48,
+            Lib_IntVector_Intrinsics_vec256_and(uu____49, s[1U + 5U * i]));
+        s[0U + 5U * i] = v023;
+        s[1U + 5U * i] = v123;
+        s[2U + 5U * i] = v223;
+        s[3U + 5U * i] = v323;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____50 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____50,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t remOut = 32U % rateInBytes;
+  uint8_t hbuf[1024U] = { 0U };
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+  memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+  Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+  Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+  Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+  Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256
+  v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+  Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+  Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+  Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+  Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+  Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+  Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+  Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256
+  v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+  Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+  Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+  Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+  Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+  Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+  Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+  Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256
+  v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+  Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+  Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+  Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+  Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+  Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+  Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+  Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256
+  v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+  Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+  Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+  Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+  Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+  Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+  Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+  Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256
+  v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+  Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+  Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+  Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+  Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+  Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+  Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+  Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256
+  v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+  Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+  Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+  Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+  Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+  Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+  Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+  Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256
+  v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+  Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+  Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+  Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+  Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+  Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+  Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+  Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256
+  v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+  Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+  Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+  Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+  ws[0U] = ws0;
+  ws[1U] = ws1;
+  ws[2U] = ws2;
+  ws[3U] = ws3;
+  ws[4U] = ws4;
+  ws[5U] = ws5;
+  ws[6U] = ws6;
+  ws[7U] = ws7;
+  ws[8U] = ws8;
+  ws[9U] = ws9;
+  ws[10U] = ws10;
+  ws[11U] = ws11;
+  ws[12U] = ws12;
+  ws[13U] = ws13;
+  ws[14U] = ws14;
+  ws[15U] = ws15;
+  ws[16U] = ws16;
+  ws[17U] = ws17;
+  ws[18U] = ws18;
+  ws[19U] = ws19;
+  ws[20U] = ws20;
+  ws[21U] = ws21;
+  ws[22U] = ws22;
+  ws[23U] = ws23;
+  ws[24U] = ws24;
+  ws[25U] = ws25;
+  ws[26U] = ws26;
+  ws[27U] = ws27;
+  ws[28U] = ws28;
+  ws[29U] = ws29;
+  ws[30U] = ws30;
+  ws[31U] = ws31;
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+  }
+  for (uint32_t i = 0U; i < remOut / 32U; i++)
+  {
+    uint8_t *b3 = rb.snd.snd.snd;
+    uint8_t *b2 = rb.snd.snd.fst;
+    uint8_t *b1 = rb.snd.fst;
+    uint8_t *b0 = rb.fst;
+    memcpy(b0 + 32U - remOut + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+    memcpy(b1 + 32U - remOut + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+    memcpy(b2 + 32U - remOut + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+    memcpy(b3 + 32U - remOut + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+  }
+  uint32_t rem0 = remOut % 32U;
+  uint32_t j = remOut / 32U;
+  uint8_t *b3 = rb.snd.snd.snd;
+  uint8_t *b2 = rb.snd.snd.fst;
+  uint8_t *b1 = rb.snd.fst;
+  uint8_t *b0 = rb.fst;
+  memcpy(b0 + 32U - remOut + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+  memcpy(b1 + 32U - remOut + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+  memcpy(b2 + 32U - remOut + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+  memcpy(b3 + 32U - remOut + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+}
+
+void
+Hacl_Hash_SHA3_Simd256_sha3_384(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+)
+{
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  rb = { .fst = output0, .snd = { .fst = output1, .snd = { .fst = output2, .snd = output3 } } };
+  uint32_t rateInBytes = 104U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 s[25U] KRML_POST_ALIGN(32) = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b00[256U] = { 0U };
+    uint8_t b10[256U] = { 0U };
+    uint8_t b20[256U] = { 0U };
+    uint8_t b30[256U] = { 0U };
+    K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+    b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+    uint8_t *b31 = ib.snd.snd.snd;
+    uint8_t *b21 = ib.snd.snd.fst;
+    uint8_t *b11 = ib.snd.fst;
+    uint8_t *b01 = ib.fst;
+    uint8_t *bl3 = b_.snd.snd.snd;
+    uint8_t *bl2 = b_.snd.snd.fst;
+    uint8_t *bl1 = b_.snd.fst;
+    uint8_t *bl0 = b_.fst;
+    memcpy(bl0, b01 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl1, b11 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl2, b21 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl3, b31 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    uint8_t *b3 = b_.snd.snd.snd;
+    uint8_t *b2 = b_.snd.snd.fst;
+    uint8_t *b1 = b_.snd.fst;
+    uint8_t *b0 = b_.fst;
+    ws[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0);
+    ws[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1);
+    ws[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2);
+    ws[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3);
+    ws[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 32U);
+    ws[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 32U);
+    ws[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 32U);
+    ws[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 32U);
+    ws[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 64U);
+    ws[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 64U);
+    ws[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 64U);
+    ws[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 64U);
+    ws[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 96U);
+    ws[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 96U);
+    ws[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 96U);
+    ws[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 96U);
+    ws[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 128U);
+    ws[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 128U);
+    ws[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 128U);
+    ws[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 128U);
+    ws[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 160U);
+    ws[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 160U);
+    ws[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 160U);
+    ws[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 160U);
+    ws[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 192U);
+    ws[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 192U);
+    ws[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 192U);
+    ws[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 192U);
+    ws[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 224U);
+    ws[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 224U);
+    ws[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 224U);
+    ws[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 224U);
+    Lib_IntVector_Intrinsics_vec256 v00 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v10 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v20 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v30 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256
+    v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__;
+    Lib_IntVector_Intrinsics_vec256 v01 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v11 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v21 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v31 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256
+    v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__0;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__0;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__0;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__0;
+    Lib_IntVector_Intrinsics_vec256 v02 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v12 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v22 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v32 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256
+    v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__1;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__1;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__1;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__1;
+    Lib_IntVector_Intrinsics_vec256 v03 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v13 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v23 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v33 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256
+    v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__2;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__2;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__2;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__2;
+    Lib_IntVector_Intrinsics_vec256 v04 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v14 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v24 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v34 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256
+    v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__3;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__3;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__3;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__3;
+    Lib_IntVector_Intrinsics_vec256 v05 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v15 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v25 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v35 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256
+    v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__4;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__4;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__4;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__4;
+    Lib_IntVector_Intrinsics_vec256 v06 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v16 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v26 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v36 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256
+    v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__5;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__5;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__5;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__5;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256
+    v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__6;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__6;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__6;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__6;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws[i]);
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____0 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____1 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____2 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____0,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____1,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____2,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____3 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____4 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____3,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____4,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____4, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____5 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____5,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____5, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____6 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____7 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v07 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____6,
+            Lib_IntVector_Intrinsics_vec256_and(uu____7, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____8 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____9 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v17 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____8,
+            Lib_IntVector_Intrinsics_vec256_and(uu____9, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____10 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____11 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v27 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____10,
+            Lib_IntVector_Intrinsics_vec256_and(uu____11, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____12 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____13 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v37 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____12,
+            Lib_IntVector_Intrinsics_vec256_and(uu____13, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____14 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____15 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____14,
+            Lib_IntVector_Intrinsics_vec256_and(uu____15, s[1U + 5U * i]));
+        s[0U + 5U * i] = v07;
+        s[1U + 5U * i] = v17;
+        s[2U + 5U * i] = v27;
+        s[3U + 5U * i] = v37;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____16 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____16,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b00[256U] = { 0U };
+  uint8_t b10[256U] = { 0U };
+  uint8_t b20[256U] = { 0U };
+  uint8_t b30[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b32 = ib.snd.snd.snd;
+  uint8_t *b22 = ib.snd.snd.fst;
+  uint8_t *b12 = ib.snd.fst;
+  uint8_t *b02 = ib.fst;
+  uint8_t *bl3 = b_.snd.snd.snd;
+  uint8_t *bl2 = b_.snd.snd.fst;
+  uint8_t *bl1 = b_.snd.fst;
+  uint8_t *bl0 = b_.fst;
+  memcpy(bl0, b02 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl1, b12 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl2, b22 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl3, b32 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b33 = b_.snd.snd.snd;
+  uint8_t *b23 = b_.snd.snd.fst;
+  uint8_t *b13 = b_.snd.fst;
+  uint8_t *b03 = b_.fst;
+  b03[rem] = 0x06U;
+  b13[rem] = 0x06U;
+  b23[rem] = 0x06U;
+  b33[rem] = 0x06U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws32[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b34 = b_.snd.snd.snd;
+  uint8_t *b24 = b_.snd.snd.fst;
+  uint8_t *b14 = b_.snd.fst;
+  uint8_t *b04 = b_.fst;
+  ws32[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04);
+  ws32[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14);
+  ws32[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24);
+  ws32[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34);
+  ws32[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 32U);
+  ws32[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 32U);
+  ws32[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 32U);
+  ws32[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 32U);
+  ws32[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 64U);
+  ws32[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 64U);
+  ws32[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 64U);
+  ws32[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 64U);
+  ws32[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 96U);
+  ws32[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 96U);
+  ws32[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 96U);
+  ws32[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 96U);
+  ws32[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 128U);
+  ws32[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 128U);
+  ws32[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 128U);
+  ws32[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 128U);
+  ws32[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 160U);
+  ws32[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 160U);
+  ws32[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 160U);
+  ws32[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 160U);
+  ws32[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 192U);
+  ws32[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 192U);
+  ws32[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 192U);
+  ws32[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 192U);
+  ws32[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 224U);
+  ws32[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 224U);
+  ws32[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 224U);
+  ws32[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v00 = ws32[0U];
+  Lib_IntVector_Intrinsics_vec256 v10 = ws32[1U];
+  Lib_IntVector_Intrinsics_vec256 v20 = ws32[2U];
+  Lib_IntVector_Intrinsics_vec256 v30 = ws32[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256
+  v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256 ws00 = v0__;
+  Lib_IntVector_Intrinsics_vec256 ws110 = v2__;
+  Lib_IntVector_Intrinsics_vec256 ws210 = v1__;
+  Lib_IntVector_Intrinsics_vec256 ws33 = v3__;
+  Lib_IntVector_Intrinsics_vec256 v01 = ws32[4U];
+  Lib_IntVector_Intrinsics_vec256 v11 = ws32[5U];
+  Lib_IntVector_Intrinsics_vec256 v21 = ws32[6U];
+  Lib_IntVector_Intrinsics_vec256 v31 = ws32[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256
+  v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256 ws40 = v0__0;
+  Lib_IntVector_Intrinsics_vec256 ws50 = v2__0;
+  Lib_IntVector_Intrinsics_vec256 ws60 = v1__0;
+  Lib_IntVector_Intrinsics_vec256 ws70 = v3__0;
+  Lib_IntVector_Intrinsics_vec256 v02 = ws32[8U];
+  Lib_IntVector_Intrinsics_vec256 v12 = ws32[9U];
+  Lib_IntVector_Intrinsics_vec256 v22 = ws32[10U];
+  Lib_IntVector_Intrinsics_vec256 v32 = ws32[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256
+  v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256 ws80 = v0__1;
+  Lib_IntVector_Intrinsics_vec256 ws90 = v2__1;
+  Lib_IntVector_Intrinsics_vec256 ws100 = v1__1;
+  Lib_IntVector_Intrinsics_vec256 ws111 = v3__1;
+  Lib_IntVector_Intrinsics_vec256 v03 = ws32[12U];
+  Lib_IntVector_Intrinsics_vec256 v13 = ws32[13U];
+  Lib_IntVector_Intrinsics_vec256 v23 = ws32[14U];
+  Lib_IntVector_Intrinsics_vec256 v33 = ws32[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256
+  v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256 ws120 = v0__2;
+  Lib_IntVector_Intrinsics_vec256 ws130 = v2__2;
+  Lib_IntVector_Intrinsics_vec256 ws140 = v1__2;
+  Lib_IntVector_Intrinsics_vec256 ws150 = v3__2;
+  Lib_IntVector_Intrinsics_vec256 v04 = ws32[16U];
+  Lib_IntVector_Intrinsics_vec256 v14 = ws32[17U];
+  Lib_IntVector_Intrinsics_vec256 v24 = ws32[18U];
+  Lib_IntVector_Intrinsics_vec256 v34 = ws32[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256
+  v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256 ws160 = v0__3;
+  Lib_IntVector_Intrinsics_vec256 ws170 = v2__3;
+  Lib_IntVector_Intrinsics_vec256 ws180 = v1__3;
+  Lib_IntVector_Intrinsics_vec256 ws190 = v3__3;
+  Lib_IntVector_Intrinsics_vec256 v05 = ws32[20U];
+  Lib_IntVector_Intrinsics_vec256 v15 = ws32[21U];
+  Lib_IntVector_Intrinsics_vec256 v25 = ws32[22U];
+  Lib_IntVector_Intrinsics_vec256 v35 = ws32[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256
+  v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256 ws200 = v0__4;
+  Lib_IntVector_Intrinsics_vec256 ws211 = v2__4;
+  Lib_IntVector_Intrinsics_vec256 ws220 = v1__4;
+  Lib_IntVector_Intrinsics_vec256 ws230 = v3__4;
+  Lib_IntVector_Intrinsics_vec256 v06 = ws32[24U];
+  Lib_IntVector_Intrinsics_vec256 v16 = ws32[25U];
+  Lib_IntVector_Intrinsics_vec256 v26 = ws32[26U];
+  Lib_IntVector_Intrinsics_vec256 v36 = ws32[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256
+  v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256 ws240 = v0__5;
+  Lib_IntVector_Intrinsics_vec256 ws250 = v2__5;
+  Lib_IntVector_Intrinsics_vec256 ws260 = v1__5;
+  Lib_IntVector_Intrinsics_vec256 ws270 = v3__5;
+  Lib_IntVector_Intrinsics_vec256 v07 = ws32[28U];
+  Lib_IntVector_Intrinsics_vec256 v17 = ws32[29U];
+  Lib_IntVector_Intrinsics_vec256 v27 = ws32[30U];
+  Lib_IntVector_Intrinsics_vec256 v37 = ws32[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256
+  v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256 ws280 = v0__6;
+  Lib_IntVector_Intrinsics_vec256 ws290 = v2__6;
+  Lib_IntVector_Intrinsics_vec256 ws300 = v1__6;
+  Lib_IntVector_Intrinsics_vec256 ws310 = v3__6;
+  ws32[0U] = ws00;
+  ws32[1U] = ws110;
+  ws32[2U] = ws210;
+  ws32[3U] = ws33;
+  ws32[4U] = ws40;
+  ws32[5U] = ws50;
+  ws32[6U] = ws60;
+  ws32[7U] = ws70;
+  ws32[8U] = ws80;
+  ws32[9U] = ws90;
+  ws32[10U] = ws100;
+  ws32[11U] = ws111;
+  ws32[12U] = ws120;
+  ws32[13U] = ws130;
+  ws32[14U] = ws140;
+  ws32[15U] = ws150;
+  ws32[16U] = ws160;
+  ws32[17U] = ws170;
+  ws32[18U] = ws180;
+  ws32[19U] = ws190;
+  ws32[20U] = ws200;
+  ws32[21U] = ws211;
+  ws32[22U] = ws220;
+  ws32[23U] = ws230;
+  ws32[24U] = ws240;
+  ws32[25U] = ws250;
+  ws32[26U] = ws260;
+  ws32[27U] = ws270;
+  ws32[28U] = ws280;
+  ws32[29U] = ws290;
+  ws32[30U] = ws300;
+  ws32[31U] = ws310;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws32[i]);
+  }
+  uint8_t b05[256U] = { 0U };
+  uint8_t b15[256U] = { 0U };
+  uint8_t b25[256U] = { 0U };
+  uint8_t b35[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b = { .fst = b05, .snd = { .fst = b15, .snd = { .fst = b25, .snd = b35 } } };
+  uint8_t *b36 = b.snd.snd.snd;
+  uint8_t *b26 = b.snd.snd.fst;
+  uint8_t *b16 = b.snd.fst;
+  uint8_t *b06 = b.fst;
+  b06[rateInBytes - 1U] = 0x80U;
+  b16[rateInBytes - 1U] = 0x80U;
+  b26[rateInBytes - 1U] = 0x80U;
+  b36[rateInBytes - 1U] = 0x80U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws34[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b37 = b.snd.snd.snd;
+  uint8_t *b27 = b.snd.snd.fst;
+  uint8_t *b17 = b.snd.fst;
+  uint8_t *b07 = b.fst;
+  ws34[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07);
+  ws34[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17);
+  ws34[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27);
+  ws34[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37);
+  ws34[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 32U);
+  ws34[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 32U);
+  ws34[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 32U);
+  ws34[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 32U);
+  ws34[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 64U);
+  ws34[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 64U);
+  ws34[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 64U);
+  ws34[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 64U);
+  ws34[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 96U);
+  ws34[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 96U);
+  ws34[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 96U);
+  ws34[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 96U);
+  ws34[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 128U);
+  ws34[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 128U);
+  ws34[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 128U);
+  ws34[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 128U);
+  ws34[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 160U);
+  ws34[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 160U);
+  ws34[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 160U);
+  ws34[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 160U);
+  ws34[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 192U);
+  ws34[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 192U);
+  ws34[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 192U);
+  ws34[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 192U);
+  ws34[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 224U);
+  ws34[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 224U);
+  ws34[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 224U);
+  ws34[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v08 = ws34[0U];
+  Lib_IntVector_Intrinsics_vec256 v18 = ws34[1U];
+  Lib_IntVector_Intrinsics_vec256 v28 = ws34[2U];
+  Lib_IntVector_Intrinsics_vec256 v38 = ws34[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v1_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v2_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v3_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v0__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v1__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v2__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256
+  v3__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256 ws01 = v0__7;
+  Lib_IntVector_Intrinsics_vec256 ws112 = v2__7;
+  Lib_IntVector_Intrinsics_vec256 ws212 = v1__7;
+  Lib_IntVector_Intrinsics_vec256 ws35 = v3__7;
+  Lib_IntVector_Intrinsics_vec256 v09 = ws34[4U];
+  Lib_IntVector_Intrinsics_vec256 v19 = ws34[5U];
+  Lib_IntVector_Intrinsics_vec256 v29 = ws34[6U];
+  Lib_IntVector_Intrinsics_vec256 v39 = ws34[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v1_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v2_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v3_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v0__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v1__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v2__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256
+  v3__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256 ws41 = v0__8;
+  Lib_IntVector_Intrinsics_vec256 ws51 = v2__8;
+  Lib_IntVector_Intrinsics_vec256 ws61 = v1__8;
+  Lib_IntVector_Intrinsics_vec256 ws71 = v3__8;
+  Lib_IntVector_Intrinsics_vec256 v010 = ws34[8U];
+  Lib_IntVector_Intrinsics_vec256 v110 = ws34[9U];
+  Lib_IntVector_Intrinsics_vec256 v210 = ws34[10U];
+  Lib_IntVector_Intrinsics_vec256 v310 = ws34[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v1_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v2_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v3_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v0__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v1__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v2__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256
+  v3__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256 ws81 = v0__9;
+  Lib_IntVector_Intrinsics_vec256 ws91 = v2__9;
+  Lib_IntVector_Intrinsics_vec256 ws101 = v1__9;
+  Lib_IntVector_Intrinsics_vec256 ws113 = v3__9;
+  Lib_IntVector_Intrinsics_vec256 v011 = ws34[12U];
+  Lib_IntVector_Intrinsics_vec256 v111 = ws34[13U];
+  Lib_IntVector_Intrinsics_vec256 v211 = ws34[14U];
+  Lib_IntVector_Intrinsics_vec256 v311 = ws34[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v1_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v2_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v3_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v0__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v1__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v2__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256
+  v3__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256 ws121 = v0__10;
+  Lib_IntVector_Intrinsics_vec256 ws131 = v2__10;
+  Lib_IntVector_Intrinsics_vec256 ws141 = v1__10;
+  Lib_IntVector_Intrinsics_vec256 ws151 = v3__10;
+  Lib_IntVector_Intrinsics_vec256 v012 = ws34[16U];
+  Lib_IntVector_Intrinsics_vec256 v112 = ws34[17U];
+  Lib_IntVector_Intrinsics_vec256 v212 = ws34[18U];
+  Lib_IntVector_Intrinsics_vec256 v312 = ws34[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v1_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v2_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v3_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v0__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v1__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v2__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256
+  v3__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256 ws161 = v0__11;
+  Lib_IntVector_Intrinsics_vec256 ws171 = v2__11;
+  Lib_IntVector_Intrinsics_vec256 ws181 = v1__11;
+  Lib_IntVector_Intrinsics_vec256 ws191 = v3__11;
+  Lib_IntVector_Intrinsics_vec256 v013 = ws34[20U];
+  Lib_IntVector_Intrinsics_vec256 v113 = ws34[21U];
+  Lib_IntVector_Intrinsics_vec256 v213 = ws34[22U];
+  Lib_IntVector_Intrinsics_vec256 v313 = ws34[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v1_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v2_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v3_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v0__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v1__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v2__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256
+  v3__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256 ws201 = v0__12;
+  Lib_IntVector_Intrinsics_vec256 ws213 = v2__12;
+  Lib_IntVector_Intrinsics_vec256 ws221 = v1__12;
+  Lib_IntVector_Intrinsics_vec256 ws231 = v3__12;
+  Lib_IntVector_Intrinsics_vec256 v014 = ws34[24U];
+  Lib_IntVector_Intrinsics_vec256 v114 = ws34[25U];
+  Lib_IntVector_Intrinsics_vec256 v214 = ws34[26U];
+  Lib_IntVector_Intrinsics_vec256 v314 = ws34[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v1_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v2_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v3_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v0__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v1__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v2__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256
+  v3__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256 ws241 = v0__13;
+  Lib_IntVector_Intrinsics_vec256 ws251 = v2__13;
+  Lib_IntVector_Intrinsics_vec256 ws261 = v1__13;
+  Lib_IntVector_Intrinsics_vec256 ws271 = v3__13;
+  Lib_IntVector_Intrinsics_vec256 v015 = ws34[28U];
+  Lib_IntVector_Intrinsics_vec256 v115 = ws34[29U];
+  Lib_IntVector_Intrinsics_vec256 v215 = ws34[30U];
+  Lib_IntVector_Intrinsics_vec256 v315 = ws34[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v1_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v2_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v3_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v0__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v1__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v2__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256
+  v3__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256 ws281 = v0__14;
+  Lib_IntVector_Intrinsics_vec256 ws291 = v2__14;
+  Lib_IntVector_Intrinsics_vec256 ws301 = v1__14;
+  Lib_IntVector_Intrinsics_vec256 ws311 = v3__14;
+  ws34[0U] = ws01;
+  ws34[1U] = ws112;
+  ws34[2U] = ws212;
+  ws34[3U] = ws35;
+  ws34[4U] = ws41;
+  ws34[5U] = ws51;
+  ws34[6U] = ws61;
+  ws34[7U] = ws71;
+  ws34[8U] = ws81;
+  ws34[9U] = ws91;
+  ws34[10U] = ws101;
+  ws34[11U] = ws113;
+  ws34[12U] = ws121;
+  ws34[13U] = ws131;
+  ws34[14U] = ws141;
+  ws34[15U] = ws151;
+  ws34[16U] = ws161;
+  ws34[17U] = ws171;
+  ws34[18U] = ws181;
+  ws34[19U] = ws191;
+  ws34[20U] = ws201;
+  ws34[21U] = ws213;
+  ws34[22U] = ws221;
+  ws34[23U] = ws231;
+  ws34[24U] = ws241;
+  ws34[25U] = ws251;
+  ws34[26U] = ws261;
+  ws34[27U] = ws271;
+  ws34[28U] = ws281;
+  ws34[29U] = ws291;
+  ws34[30U] = ws301;
+  ws34[31U] = ws311;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws34[i]);
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____17 = s[i + 0U];
+      Lib_IntVector_Intrinsics_vec256 uu____18 = s[i + 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____19 = s[i + 10U];
+      _C[i] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____17,
+          Lib_IntVector_Intrinsics_vec256_xor(uu____18,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____19,
+              Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____20 = _C[(i1 + 4U) % 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____21 = _C[(i1 + 1U) % 5U];
+      Lib_IntVector_Intrinsics_vec256
+      _D =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____20,
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____21,
+              1U),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____21, 63U)));
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        s[i1 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i1 + 5U * i], _D);););
+    Lib_IntVector_Intrinsics_vec256 x = s[1U];
+    Lib_IntVector_Intrinsics_vec256 current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+      Lib_IntVector_Intrinsics_vec256 uu____22 = current;
+      s[_Y] =
+        Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____22, r),
+          Lib_IntVector_Intrinsics_vec256_shift_right64(uu____22, 64U - r));
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____23 = s[0U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____24 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v0 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____23,
+          Lib_IntVector_Intrinsics_vec256_and(uu____24, s[2U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____25 = s[1U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____26 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v1 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____25,
+          Lib_IntVector_Intrinsics_vec256_and(uu____26, s[3U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____27 = s[2U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____28 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v2 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____27,
+          Lib_IntVector_Intrinsics_vec256_and(uu____28, s[4U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____29 = s[3U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____30 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v3 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____29,
+          Lib_IntVector_Intrinsics_vec256_and(uu____30, s[0U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____31 = s[4U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____32 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v4 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____31,
+          Lib_IntVector_Intrinsics_vec256_and(uu____32, s[1U + 5U * i]));
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    Lib_IntVector_Intrinsics_vec256 uu____33 = s[0U];
+    s[0U] =
+      Lib_IntVector_Intrinsics_vec256_xor(uu____33,
+        Lib_IntVector_Intrinsics_vec256_load64(c));
+  }
+  for (uint32_t i0 = 0U; i0 < 48U / rateInBytes; i0++)
+  {
+    uint8_t hbuf[1024U] = { 0U };
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+    Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256
+    v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+    Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256
+    v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+    Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256
+    v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+    Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256
+    v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+    Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256
+    v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+    Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256
+    v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+    Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256
+    v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256
+    v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+    }
+    for (uint32_t i = 0U; i < rateInBytes / 32U; i++)
+    {
+      uint8_t *b31 = rb.snd.snd.snd;
+      uint8_t *b21 = rb.snd.snd.fst;
+      uint8_t *b11 = rb.snd.fst;
+      uint8_t *b01 = rb.fst;
+      memcpy(b01 + i0 * rateInBytes + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+      memcpy(b11 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+      memcpy(b21 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+      memcpy(b31 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+    }
+    uint32_t rem0 = rateInBytes % 32U;
+    uint32_t j = rateInBytes / 32U;
+    uint8_t *b31 = rb.snd.snd.snd;
+    uint8_t *b21 = rb.snd.snd.fst;
+    uint8_t *b11 = rb.snd.fst;
+    uint8_t *b01 = rb.fst;
+    memcpy(b01 + i0 * rateInBytes + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+    memcpy(b11 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+    memcpy(b21 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+    memcpy(b31 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____34 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____35 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____36 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____34,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____35,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____36,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____37 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____38 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____37,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____38,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____38, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____39 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____39,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____39, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____40 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____41 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v023 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____40,
+            Lib_IntVector_Intrinsics_vec256_and(uu____41, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____42 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____43 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v123 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____42,
+            Lib_IntVector_Intrinsics_vec256_and(uu____43, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____44 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____45 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v223 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____44,
+            Lib_IntVector_Intrinsics_vec256_and(uu____45, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____46 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____47 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v323 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____46,
+            Lib_IntVector_Intrinsics_vec256_and(uu____47, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____48 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____49 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____48,
+            Lib_IntVector_Intrinsics_vec256_and(uu____49, s[1U + 5U * i]));
+        s[0U + 5U * i] = v023;
+        s[1U + 5U * i] = v123;
+        s[2U + 5U * i] = v223;
+        s[3U + 5U * i] = v323;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____50 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____50,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t remOut = 48U % rateInBytes;
+  uint8_t hbuf[1024U] = { 0U };
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+  memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+  Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+  Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+  Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+  Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256
+  v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+  Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+  Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+  Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+  Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+  Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+  Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+  Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256
+  v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+  Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+  Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+  Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+  Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+  Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+  Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+  Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256
+  v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+  Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+  Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+  Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+  Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+  Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+  Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+  Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256
+  v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+  Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+  Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+  Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+  Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+  Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+  Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+  Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256
+  v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+  Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+  Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+  Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+  Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+  Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+  Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+  Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256
+  v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+  Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+  Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+  Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+  Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+  Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+  Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+  Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256
+  v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+  Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+  Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+  Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+  Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+  Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+  Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+  Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256
+  v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+  Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+  Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+  Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+  ws[0U] = ws0;
+  ws[1U] = ws1;
+  ws[2U] = ws2;
+  ws[3U] = ws3;
+  ws[4U] = ws4;
+  ws[5U] = ws5;
+  ws[6U] = ws6;
+  ws[7U] = ws7;
+  ws[8U] = ws8;
+  ws[9U] = ws9;
+  ws[10U] = ws10;
+  ws[11U] = ws11;
+  ws[12U] = ws12;
+  ws[13U] = ws13;
+  ws[14U] = ws14;
+  ws[15U] = ws15;
+  ws[16U] = ws16;
+  ws[17U] = ws17;
+  ws[18U] = ws18;
+  ws[19U] = ws19;
+  ws[20U] = ws20;
+  ws[21U] = ws21;
+  ws[22U] = ws22;
+  ws[23U] = ws23;
+  ws[24U] = ws24;
+  ws[25U] = ws25;
+  ws[26U] = ws26;
+  ws[27U] = ws27;
+  ws[28U] = ws28;
+  ws[29U] = ws29;
+  ws[30U] = ws30;
+  ws[31U] = ws31;
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+  }
+  for (uint32_t i = 0U; i < remOut / 32U; i++)
+  {
+    uint8_t *b3 = rb.snd.snd.snd;
+    uint8_t *b2 = rb.snd.snd.fst;
+    uint8_t *b1 = rb.snd.fst;
+    uint8_t *b0 = rb.fst;
+    memcpy(b0 + 48U - remOut + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+    memcpy(b1 + 48U - remOut + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+    memcpy(b2 + 48U - remOut + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+    memcpy(b3 + 48U - remOut + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+  }
+  uint32_t rem0 = remOut % 32U;
+  uint32_t j = remOut / 32U;
+  uint8_t *b3 = rb.snd.snd.snd;
+  uint8_t *b2 = rb.snd.snd.fst;
+  uint8_t *b1 = rb.snd.fst;
+  uint8_t *b0 = rb.fst;
+  memcpy(b0 + 48U - remOut + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+  memcpy(b1 + 48U - remOut + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+  memcpy(b2 + 48U - remOut + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+  memcpy(b3 + 48U - remOut + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+}
+
+void
+Hacl_Hash_SHA3_Simd256_sha3_512(
+  uint32_t inputByteLen,
+  uint8_t *input0,
+  uint8_t *input1,
+  uint8_t *input2,
+  uint8_t *input3,
+  uint8_t *output0,
+  uint8_t *output1,
+  uint8_t *output2,
+  uint8_t *output3
+)
+{
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  ib = { .fst = input0, .snd = { .fst = input1, .snd = { .fst = input2, .snd = input3 } } };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  rb = { .fst = output0, .snd = { .fst = output1, .snd = { .fst = output2, .snd = output3 } } };
+  uint32_t rateInBytes = 72U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 s[25U] KRML_POST_ALIGN(32) = { 0U };
+  for (uint32_t i0 = 0U; i0 < inputByteLen / rateInBytes; i0++)
+  {
+    uint8_t b00[256U] = { 0U };
+    uint8_t b10[256U] = { 0U };
+    uint8_t b20[256U] = { 0U };
+    uint8_t b30[256U] = { 0U };
+    K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+    b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+    uint8_t *b31 = ib.snd.snd.snd;
+    uint8_t *b21 = ib.snd.snd.fst;
+    uint8_t *b11 = ib.snd.fst;
+    uint8_t *b01 = ib.fst;
+    uint8_t *bl3 = b_.snd.snd.snd;
+    uint8_t *bl2 = b_.snd.snd.fst;
+    uint8_t *bl1 = b_.snd.fst;
+    uint8_t *bl0 = b_.fst;
+    memcpy(bl0, b01 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl1, b11 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl2, b21 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    memcpy(bl3, b31 + i0 * rateInBytes, rateInBytes * sizeof (uint8_t));
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    uint8_t *b3 = b_.snd.snd.snd;
+    uint8_t *b2 = b_.snd.snd.fst;
+    uint8_t *b1 = b_.snd.fst;
+    uint8_t *b0 = b_.fst;
+    ws[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0);
+    ws[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1);
+    ws[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2);
+    ws[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3);
+    ws[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 32U);
+    ws[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 32U);
+    ws[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 32U);
+    ws[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 32U);
+    ws[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 64U);
+    ws[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 64U);
+    ws[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 64U);
+    ws[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 64U);
+    ws[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 96U);
+    ws[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 96U);
+    ws[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 96U);
+    ws[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 96U);
+    ws[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 128U);
+    ws[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 128U);
+    ws[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 128U);
+    ws[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 128U);
+    ws[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 160U);
+    ws[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 160U);
+    ws[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 160U);
+    ws[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 160U);
+    ws[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 192U);
+    ws[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 192U);
+    ws[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 192U);
+    ws[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 192U);
+    ws[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b0 + 224U);
+    ws[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b1 + 224U);
+    ws[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b2 + 224U);
+    ws[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b3 + 224U);
+    Lib_IntVector_Intrinsics_vec256 v00 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v10 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v20 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v30 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+    Lib_IntVector_Intrinsics_vec256
+    v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+    Lib_IntVector_Intrinsics_vec256
+    v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+    Lib_IntVector_Intrinsics_vec256
+    v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256
+    v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__;
+    Lib_IntVector_Intrinsics_vec256 v01 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v11 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v21 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v31 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+    Lib_IntVector_Intrinsics_vec256
+    v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+    Lib_IntVector_Intrinsics_vec256
+    v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+    Lib_IntVector_Intrinsics_vec256
+    v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256
+    v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__0;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__0;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__0;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__0;
+    Lib_IntVector_Intrinsics_vec256 v02 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v12 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v22 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v32 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+    Lib_IntVector_Intrinsics_vec256
+    v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+    Lib_IntVector_Intrinsics_vec256
+    v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+    Lib_IntVector_Intrinsics_vec256
+    v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256
+    v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__1;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__1;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__1;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__1;
+    Lib_IntVector_Intrinsics_vec256 v03 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v13 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v23 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v33 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+    Lib_IntVector_Intrinsics_vec256
+    v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+    Lib_IntVector_Intrinsics_vec256
+    v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+    Lib_IntVector_Intrinsics_vec256
+    v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256
+    v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__2;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__2;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__2;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__2;
+    Lib_IntVector_Intrinsics_vec256 v04 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v14 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v24 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v34 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+    Lib_IntVector_Intrinsics_vec256
+    v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+    Lib_IntVector_Intrinsics_vec256
+    v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+    Lib_IntVector_Intrinsics_vec256
+    v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256
+    v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__3;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__3;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__3;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__3;
+    Lib_IntVector_Intrinsics_vec256 v05 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v15 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v25 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v35 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+    Lib_IntVector_Intrinsics_vec256
+    v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+    Lib_IntVector_Intrinsics_vec256
+    v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+    Lib_IntVector_Intrinsics_vec256
+    v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256
+    v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__4;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__4;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__4;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__4;
+    Lib_IntVector_Intrinsics_vec256 v06 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v16 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v26 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v36 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+    Lib_IntVector_Intrinsics_vec256
+    v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+    Lib_IntVector_Intrinsics_vec256
+    v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+    Lib_IntVector_Intrinsics_vec256
+    v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256
+    v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__5;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__5;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__5;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__5;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+    Lib_IntVector_Intrinsics_vec256
+    v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256
+    v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__6;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__6;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__6;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__6;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 25U; i++)
+    {
+      s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws[i]);
+    }
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____0 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____1 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____2 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____0,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____1,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____2,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____3 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____4 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____3,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____4,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____4, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____5 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____5,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____5, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____6 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____7 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v07 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____6,
+            Lib_IntVector_Intrinsics_vec256_and(uu____7, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____8 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____9 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v17 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____8,
+            Lib_IntVector_Intrinsics_vec256_and(uu____9, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____10 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____11 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v27 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____10,
+            Lib_IntVector_Intrinsics_vec256_and(uu____11, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____12 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____13 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v37 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____12,
+            Lib_IntVector_Intrinsics_vec256_and(uu____13, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____14 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____15 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____14,
+            Lib_IntVector_Intrinsics_vec256_and(uu____15, s[1U + 5U * i]));
+        s[0U + 5U * i] = v07;
+        s[1U + 5U * i] = v17;
+        s[2U + 5U * i] = v27;
+        s[3U + 5U * i] = v37;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____16 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____16,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t rem = inputByteLen % rateInBytes;
+  uint8_t b00[256U] = { 0U };
+  uint8_t b10[256U] = { 0U };
+  uint8_t b20[256U] = { 0U };
+  uint8_t b30[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b_ = { .fst = b00, .snd = { .fst = b10, .snd = { .fst = b20, .snd = b30 } } };
+  uint32_t rem1 = inputByteLen % rateInBytes;
+  uint8_t *b32 = ib.snd.snd.snd;
+  uint8_t *b22 = ib.snd.snd.fst;
+  uint8_t *b12 = ib.snd.fst;
+  uint8_t *b02 = ib.fst;
+  uint8_t *bl3 = b_.snd.snd.snd;
+  uint8_t *bl2 = b_.snd.snd.fst;
+  uint8_t *bl1 = b_.snd.fst;
+  uint8_t *bl0 = b_.fst;
+  memcpy(bl0, b02 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl1, b12 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl2, b22 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  memcpy(bl3, b32 + inputByteLen - rem1, rem1 * sizeof (uint8_t));
+  uint8_t *b33 = b_.snd.snd.snd;
+  uint8_t *b23 = b_.snd.snd.fst;
+  uint8_t *b13 = b_.snd.fst;
+  uint8_t *b03 = b_.fst;
+  b03[rem] = 0x06U;
+  b13[rem] = 0x06U;
+  b23[rem] = 0x06U;
+  b33[rem] = 0x06U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws32[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b34 = b_.snd.snd.snd;
+  uint8_t *b24 = b_.snd.snd.fst;
+  uint8_t *b14 = b_.snd.fst;
+  uint8_t *b04 = b_.fst;
+  ws32[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04);
+  ws32[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14);
+  ws32[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24);
+  ws32[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34);
+  ws32[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 32U);
+  ws32[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 32U);
+  ws32[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 32U);
+  ws32[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 32U);
+  ws32[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 64U);
+  ws32[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 64U);
+  ws32[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 64U);
+  ws32[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 64U);
+  ws32[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 96U);
+  ws32[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 96U);
+  ws32[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 96U);
+  ws32[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 96U);
+  ws32[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 128U);
+  ws32[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 128U);
+  ws32[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 128U);
+  ws32[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 128U);
+  ws32[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 160U);
+  ws32[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 160U);
+  ws32[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 160U);
+  ws32[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 160U);
+  ws32[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 192U);
+  ws32[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 192U);
+  ws32[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 192U);
+  ws32[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 192U);
+  ws32[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b04 + 224U);
+  ws32[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b14 + 224U);
+  ws32[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b24 + 224U);
+  ws32[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b34 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v00 = ws32[0U];
+  Lib_IntVector_Intrinsics_vec256 v10 = ws32[1U];
+  Lib_IntVector_Intrinsics_vec256 v20 = ws32[2U];
+  Lib_IntVector_Intrinsics_vec256 v30 = ws32[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v1_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v00, v10);
+  Lib_IntVector_Intrinsics_vec256
+  v2_ = Lib_IntVector_Intrinsics_vec256_interleave_low64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v3_ = Lib_IntVector_Intrinsics_vec256_interleave_high64(v20, v30);
+  Lib_IntVector_Intrinsics_vec256
+  v0__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v1__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_, v2_);
+  Lib_IntVector_Intrinsics_vec256
+  v2__ = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256
+  v3__ = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_, v3_);
+  Lib_IntVector_Intrinsics_vec256 ws00 = v0__;
+  Lib_IntVector_Intrinsics_vec256 ws110 = v2__;
+  Lib_IntVector_Intrinsics_vec256 ws210 = v1__;
+  Lib_IntVector_Intrinsics_vec256 ws33 = v3__;
+  Lib_IntVector_Intrinsics_vec256 v01 = ws32[4U];
+  Lib_IntVector_Intrinsics_vec256 v11 = ws32[5U];
+  Lib_IntVector_Intrinsics_vec256 v21 = ws32[6U];
+  Lib_IntVector_Intrinsics_vec256 v31 = ws32[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v1_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v01, v11);
+  Lib_IntVector_Intrinsics_vec256
+  v2_0 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v3_0 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v21, v31);
+  Lib_IntVector_Intrinsics_vec256
+  v0__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v1__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_0, v2_0);
+  Lib_IntVector_Intrinsics_vec256
+  v2__0 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256
+  v3__0 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_0, v3_0);
+  Lib_IntVector_Intrinsics_vec256 ws40 = v0__0;
+  Lib_IntVector_Intrinsics_vec256 ws50 = v2__0;
+  Lib_IntVector_Intrinsics_vec256 ws60 = v1__0;
+  Lib_IntVector_Intrinsics_vec256 ws70 = v3__0;
+  Lib_IntVector_Intrinsics_vec256 v02 = ws32[8U];
+  Lib_IntVector_Intrinsics_vec256 v12 = ws32[9U];
+  Lib_IntVector_Intrinsics_vec256 v22 = ws32[10U];
+  Lib_IntVector_Intrinsics_vec256 v32 = ws32[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v1_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v02, v12);
+  Lib_IntVector_Intrinsics_vec256
+  v2_1 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v3_1 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v22, v32);
+  Lib_IntVector_Intrinsics_vec256
+  v0__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v1__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_1, v2_1);
+  Lib_IntVector_Intrinsics_vec256
+  v2__1 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256
+  v3__1 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_1, v3_1);
+  Lib_IntVector_Intrinsics_vec256 ws80 = v0__1;
+  Lib_IntVector_Intrinsics_vec256 ws90 = v2__1;
+  Lib_IntVector_Intrinsics_vec256 ws100 = v1__1;
+  Lib_IntVector_Intrinsics_vec256 ws111 = v3__1;
+  Lib_IntVector_Intrinsics_vec256 v03 = ws32[12U];
+  Lib_IntVector_Intrinsics_vec256 v13 = ws32[13U];
+  Lib_IntVector_Intrinsics_vec256 v23 = ws32[14U];
+  Lib_IntVector_Intrinsics_vec256 v33 = ws32[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v1_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v03, v13);
+  Lib_IntVector_Intrinsics_vec256
+  v2_2 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v3_2 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v23, v33);
+  Lib_IntVector_Intrinsics_vec256
+  v0__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v1__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_2, v2_2);
+  Lib_IntVector_Intrinsics_vec256
+  v2__2 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256
+  v3__2 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_2, v3_2);
+  Lib_IntVector_Intrinsics_vec256 ws120 = v0__2;
+  Lib_IntVector_Intrinsics_vec256 ws130 = v2__2;
+  Lib_IntVector_Intrinsics_vec256 ws140 = v1__2;
+  Lib_IntVector_Intrinsics_vec256 ws150 = v3__2;
+  Lib_IntVector_Intrinsics_vec256 v04 = ws32[16U];
+  Lib_IntVector_Intrinsics_vec256 v14 = ws32[17U];
+  Lib_IntVector_Intrinsics_vec256 v24 = ws32[18U];
+  Lib_IntVector_Intrinsics_vec256 v34 = ws32[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v1_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v04, v14);
+  Lib_IntVector_Intrinsics_vec256
+  v2_3 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v3_3 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v24, v34);
+  Lib_IntVector_Intrinsics_vec256
+  v0__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v1__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_3, v2_3);
+  Lib_IntVector_Intrinsics_vec256
+  v2__3 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256
+  v3__3 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_3, v3_3);
+  Lib_IntVector_Intrinsics_vec256 ws160 = v0__3;
+  Lib_IntVector_Intrinsics_vec256 ws170 = v2__3;
+  Lib_IntVector_Intrinsics_vec256 ws180 = v1__3;
+  Lib_IntVector_Intrinsics_vec256 ws190 = v3__3;
+  Lib_IntVector_Intrinsics_vec256 v05 = ws32[20U];
+  Lib_IntVector_Intrinsics_vec256 v15 = ws32[21U];
+  Lib_IntVector_Intrinsics_vec256 v25 = ws32[22U];
+  Lib_IntVector_Intrinsics_vec256 v35 = ws32[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v1_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v05, v15);
+  Lib_IntVector_Intrinsics_vec256
+  v2_4 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v3_4 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v25, v35);
+  Lib_IntVector_Intrinsics_vec256
+  v0__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v1__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_4, v2_4);
+  Lib_IntVector_Intrinsics_vec256
+  v2__4 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256
+  v3__4 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_4, v3_4);
+  Lib_IntVector_Intrinsics_vec256 ws200 = v0__4;
+  Lib_IntVector_Intrinsics_vec256 ws211 = v2__4;
+  Lib_IntVector_Intrinsics_vec256 ws220 = v1__4;
+  Lib_IntVector_Intrinsics_vec256 ws230 = v3__4;
+  Lib_IntVector_Intrinsics_vec256 v06 = ws32[24U];
+  Lib_IntVector_Intrinsics_vec256 v16 = ws32[25U];
+  Lib_IntVector_Intrinsics_vec256 v26 = ws32[26U];
+  Lib_IntVector_Intrinsics_vec256 v36 = ws32[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v1_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v06, v16);
+  Lib_IntVector_Intrinsics_vec256
+  v2_5 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v3_5 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v26, v36);
+  Lib_IntVector_Intrinsics_vec256
+  v0__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v1__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_5, v2_5);
+  Lib_IntVector_Intrinsics_vec256
+  v2__5 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256
+  v3__5 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_5, v3_5);
+  Lib_IntVector_Intrinsics_vec256 ws240 = v0__5;
+  Lib_IntVector_Intrinsics_vec256 ws250 = v2__5;
+  Lib_IntVector_Intrinsics_vec256 ws260 = v1__5;
+  Lib_IntVector_Intrinsics_vec256 ws270 = v3__5;
+  Lib_IntVector_Intrinsics_vec256 v07 = ws32[28U];
+  Lib_IntVector_Intrinsics_vec256 v17 = ws32[29U];
+  Lib_IntVector_Intrinsics_vec256 v27 = ws32[30U];
+  Lib_IntVector_Intrinsics_vec256 v37 = ws32[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v1_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v07, v17);
+  Lib_IntVector_Intrinsics_vec256
+  v2_6 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v3_6 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v27, v37);
+  Lib_IntVector_Intrinsics_vec256
+  v0__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v1__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_6, v2_6);
+  Lib_IntVector_Intrinsics_vec256
+  v2__6 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256
+  v3__6 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_6, v3_6);
+  Lib_IntVector_Intrinsics_vec256 ws280 = v0__6;
+  Lib_IntVector_Intrinsics_vec256 ws290 = v2__6;
+  Lib_IntVector_Intrinsics_vec256 ws300 = v1__6;
+  Lib_IntVector_Intrinsics_vec256 ws310 = v3__6;
+  ws32[0U] = ws00;
+  ws32[1U] = ws110;
+  ws32[2U] = ws210;
+  ws32[3U] = ws33;
+  ws32[4U] = ws40;
+  ws32[5U] = ws50;
+  ws32[6U] = ws60;
+  ws32[7U] = ws70;
+  ws32[8U] = ws80;
+  ws32[9U] = ws90;
+  ws32[10U] = ws100;
+  ws32[11U] = ws111;
+  ws32[12U] = ws120;
+  ws32[13U] = ws130;
+  ws32[14U] = ws140;
+  ws32[15U] = ws150;
+  ws32[16U] = ws160;
+  ws32[17U] = ws170;
+  ws32[18U] = ws180;
+  ws32[19U] = ws190;
+  ws32[20U] = ws200;
+  ws32[21U] = ws211;
+  ws32[22U] = ws220;
+  ws32[23U] = ws230;
+  ws32[24U] = ws240;
+  ws32[25U] = ws250;
+  ws32[26U] = ws260;
+  ws32[27U] = ws270;
+  ws32[28U] = ws280;
+  ws32[29U] = ws290;
+  ws32[30U] = ws300;
+  ws32[31U] = ws310;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws32[i]);
+  }
+  uint8_t b05[256U] = { 0U };
+  uint8_t b15[256U] = { 0U };
+  uint8_t b25[256U] = { 0U };
+  uint8_t b35[256U] = { 0U };
+  K____uint8_t___uint8_t____K____uint8_t___uint8_t_
+  b = { .fst = b05, .snd = { .fst = b15, .snd = { .fst = b25, .snd = b35 } } };
+  uint8_t *b36 = b.snd.snd.snd;
+  uint8_t *b26 = b.snd.snd.fst;
+  uint8_t *b16 = b.snd.fst;
+  uint8_t *b06 = b.fst;
+  b06[rateInBytes - 1U] = 0x80U;
+  b16[rateInBytes - 1U] = 0x80U;
+  b26[rateInBytes - 1U] = 0x80U;
+  b36[rateInBytes - 1U] = 0x80U;
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws34[32U] KRML_POST_ALIGN(32) = { 0U };
+  uint8_t *b37 = b.snd.snd.snd;
+  uint8_t *b27 = b.snd.snd.fst;
+  uint8_t *b17 = b.snd.fst;
+  uint8_t *b07 = b.fst;
+  ws34[0U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07);
+  ws34[1U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17);
+  ws34[2U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27);
+  ws34[3U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37);
+  ws34[4U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 32U);
+  ws34[5U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 32U);
+  ws34[6U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 32U);
+  ws34[7U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 32U);
+  ws34[8U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 64U);
+  ws34[9U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 64U);
+  ws34[10U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 64U);
+  ws34[11U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 64U);
+  ws34[12U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 96U);
+  ws34[13U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 96U);
+  ws34[14U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 96U);
+  ws34[15U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 96U);
+  ws34[16U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 128U);
+  ws34[17U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 128U);
+  ws34[18U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 128U);
+  ws34[19U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 128U);
+  ws34[20U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 160U);
+  ws34[21U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 160U);
+  ws34[22U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 160U);
+  ws34[23U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 160U);
+  ws34[24U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 192U);
+  ws34[25U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 192U);
+  ws34[26U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 192U);
+  ws34[27U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 192U);
+  ws34[28U] = Lib_IntVector_Intrinsics_vec256_load64_le(b07 + 224U);
+  ws34[29U] = Lib_IntVector_Intrinsics_vec256_load64_le(b17 + 224U);
+  ws34[30U] = Lib_IntVector_Intrinsics_vec256_load64_le(b27 + 224U);
+  ws34[31U] = Lib_IntVector_Intrinsics_vec256_load64_le(b37 + 224U);
+  Lib_IntVector_Intrinsics_vec256 v08 = ws34[0U];
+  Lib_IntVector_Intrinsics_vec256 v18 = ws34[1U];
+  Lib_IntVector_Intrinsics_vec256 v28 = ws34[2U];
+  Lib_IntVector_Intrinsics_vec256 v38 = ws34[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v1_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v08, v18);
+  Lib_IntVector_Intrinsics_vec256
+  v2_7 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v3_7 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v28, v38);
+  Lib_IntVector_Intrinsics_vec256
+  v0__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v1__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_7, v2_7);
+  Lib_IntVector_Intrinsics_vec256
+  v2__7 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256
+  v3__7 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_7, v3_7);
+  Lib_IntVector_Intrinsics_vec256 ws01 = v0__7;
+  Lib_IntVector_Intrinsics_vec256 ws112 = v2__7;
+  Lib_IntVector_Intrinsics_vec256 ws212 = v1__7;
+  Lib_IntVector_Intrinsics_vec256 ws35 = v3__7;
+  Lib_IntVector_Intrinsics_vec256 v09 = ws34[4U];
+  Lib_IntVector_Intrinsics_vec256 v19 = ws34[5U];
+  Lib_IntVector_Intrinsics_vec256 v29 = ws34[6U];
+  Lib_IntVector_Intrinsics_vec256 v39 = ws34[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v1_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v09, v19);
+  Lib_IntVector_Intrinsics_vec256
+  v2_8 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v3_8 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v29, v39);
+  Lib_IntVector_Intrinsics_vec256
+  v0__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v1__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_8, v2_8);
+  Lib_IntVector_Intrinsics_vec256
+  v2__8 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256
+  v3__8 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_8, v3_8);
+  Lib_IntVector_Intrinsics_vec256 ws41 = v0__8;
+  Lib_IntVector_Intrinsics_vec256 ws51 = v2__8;
+  Lib_IntVector_Intrinsics_vec256 ws61 = v1__8;
+  Lib_IntVector_Intrinsics_vec256 ws71 = v3__8;
+  Lib_IntVector_Intrinsics_vec256 v010 = ws34[8U];
+  Lib_IntVector_Intrinsics_vec256 v110 = ws34[9U];
+  Lib_IntVector_Intrinsics_vec256 v210 = ws34[10U];
+  Lib_IntVector_Intrinsics_vec256 v310 = ws34[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v1_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v010, v110);
+  Lib_IntVector_Intrinsics_vec256
+  v2_9 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v3_9 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v210, v310);
+  Lib_IntVector_Intrinsics_vec256
+  v0__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v1__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_9, v2_9);
+  Lib_IntVector_Intrinsics_vec256
+  v2__9 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256
+  v3__9 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_9, v3_9);
+  Lib_IntVector_Intrinsics_vec256 ws81 = v0__9;
+  Lib_IntVector_Intrinsics_vec256 ws91 = v2__9;
+  Lib_IntVector_Intrinsics_vec256 ws101 = v1__9;
+  Lib_IntVector_Intrinsics_vec256 ws113 = v3__9;
+  Lib_IntVector_Intrinsics_vec256 v011 = ws34[12U];
+  Lib_IntVector_Intrinsics_vec256 v111 = ws34[13U];
+  Lib_IntVector_Intrinsics_vec256 v211 = ws34[14U];
+  Lib_IntVector_Intrinsics_vec256 v311 = ws34[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v1_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v011, v111);
+  Lib_IntVector_Intrinsics_vec256
+  v2_10 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v3_10 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v211, v311);
+  Lib_IntVector_Intrinsics_vec256
+  v0__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v1__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_10, v2_10);
+  Lib_IntVector_Intrinsics_vec256
+  v2__10 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256
+  v3__10 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_10, v3_10);
+  Lib_IntVector_Intrinsics_vec256 ws121 = v0__10;
+  Lib_IntVector_Intrinsics_vec256 ws131 = v2__10;
+  Lib_IntVector_Intrinsics_vec256 ws141 = v1__10;
+  Lib_IntVector_Intrinsics_vec256 ws151 = v3__10;
+  Lib_IntVector_Intrinsics_vec256 v012 = ws34[16U];
+  Lib_IntVector_Intrinsics_vec256 v112 = ws34[17U];
+  Lib_IntVector_Intrinsics_vec256 v212 = ws34[18U];
+  Lib_IntVector_Intrinsics_vec256 v312 = ws34[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v1_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v012, v112);
+  Lib_IntVector_Intrinsics_vec256
+  v2_11 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v3_11 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v212, v312);
+  Lib_IntVector_Intrinsics_vec256
+  v0__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v1__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_11, v2_11);
+  Lib_IntVector_Intrinsics_vec256
+  v2__11 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256
+  v3__11 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_11, v3_11);
+  Lib_IntVector_Intrinsics_vec256 ws161 = v0__11;
+  Lib_IntVector_Intrinsics_vec256 ws171 = v2__11;
+  Lib_IntVector_Intrinsics_vec256 ws181 = v1__11;
+  Lib_IntVector_Intrinsics_vec256 ws191 = v3__11;
+  Lib_IntVector_Intrinsics_vec256 v013 = ws34[20U];
+  Lib_IntVector_Intrinsics_vec256 v113 = ws34[21U];
+  Lib_IntVector_Intrinsics_vec256 v213 = ws34[22U];
+  Lib_IntVector_Intrinsics_vec256 v313 = ws34[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v1_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v013, v113);
+  Lib_IntVector_Intrinsics_vec256
+  v2_12 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v3_12 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v213, v313);
+  Lib_IntVector_Intrinsics_vec256
+  v0__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v1__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_12, v2_12);
+  Lib_IntVector_Intrinsics_vec256
+  v2__12 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256
+  v3__12 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_12, v3_12);
+  Lib_IntVector_Intrinsics_vec256 ws201 = v0__12;
+  Lib_IntVector_Intrinsics_vec256 ws213 = v2__12;
+  Lib_IntVector_Intrinsics_vec256 ws221 = v1__12;
+  Lib_IntVector_Intrinsics_vec256 ws231 = v3__12;
+  Lib_IntVector_Intrinsics_vec256 v014 = ws34[24U];
+  Lib_IntVector_Intrinsics_vec256 v114 = ws34[25U];
+  Lib_IntVector_Intrinsics_vec256 v214 = ws34[26U];
+  Lib_IntVector_Intrinsics_vec256 v314 = ws34[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v1_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v014, v114);
+  Lib_IntVector_Intrinsics_vec256
+  v2_13 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v3_13 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v214, v314);
+  Lib_IntVector_Intrinsics_vec256
+  v0__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v1__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_13, v2_13);
+  Lib_IntVector_Intrinsics_vec256
+  v2__13 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256
+  v3__13 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_13, v3_13);
+  Lib_IntVector_Intrinsics_vec256 ws241 = v0__13;
+  Lib_IntVector_Intrinsics_vec256 ws251 = v2__13;
+  Lib_IntVector_Intrinsics_vec256 ws261 = v1__13;
+  Lib_IntVector_Intrinsics_vec256 ws271 = v3__13;
+  Lib_IntVector_Intrinsics_vec256 v015 = ws34[28U];
+  Lib_IntVector_Intrinsics_vec256 v115 = ws34[29U];
+  Lib_IntVector_Intrinsics_vec256 v215 = ws34[30U];
+  Lib_IntVector_Intrinsics_vec256 v315 = ws34[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v1_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v015, v115);
+  Lib_IntVector_Intrinsics_vec256
+  v2_14 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v3_14 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v215, v315);
+  Lib_IntVector_Intrinsics_vec256
+  v0__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v1__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_14, v2_14);
+  Lib_IntVector_Intrinsics_vec256
+  v2__14 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256
+  v3__14 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_14, v3_14);
+  Lib_IntVector_Intrinsics_vec256 ws281 = v0__14;
+  Lib_IntVector_Intrinsics_vec256 ws291 = v2__14;
+  Lib_IntVector_Intrinsics_vec256 ws301 = v1__14;
+  Lib_IntVector_Intrinsics_vec256 ws311 = v3__14;
+  ws34[0U] = ws01;
+  ws34[1U] = ws112;
+  ws34[2U] = ws212;
+  ws34[3U] = ws35;
+  ws34[4U] = ws41;
+  ws34[5U] = ws51;
+  ws34[6U] = ws61;
+  ws34[7U] = ws71;
+  ws34[8U] = ws81;
+  ws34[9U] = ws91;
+  ws34[10U] = ws101;
+  ws34[11U] = ws113;
+  ws34[12U] = ws121;
+  ws34[13U] = ws131;
+  ws34[14U] = ws141;
+  ws34[15U] = ws151;
+  ws34[16U] = ws161;
+  ws34[17U] = ws171;
+  ws34[18U] = ws181;
+  ws34[19U] = ws191;
+  ws34[20U] = ws201;
+  ws34[21U] = ws213;
+  ws34[22U] = ws221;
+  ws34[23U] = ws231;
+  ws34[24U] = ws241;
+  ws34[25U] = ws251;
+  ws34[26U] = ws261;
+  ws34[27U] = ws271;
+  ws34[28U] = ws281;
+  ws34[29U] = ws291;
+  ws34[30U] = ws301;
+  ws34[31U] = ws311;
+  for (uint32_t i = 0U; i < 25U; i++)
+  {
+    s[i] = Lib_IntVector_Intrinsics_vec256_xor(s[i], ws34[i]);
+  }
+  for (uint32_t i0 = 0U; i0 < 24U; i0++)
+  {
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____17 = s[i + 0U];
+      Lib_IntVector_Intrinsics_vec256 uu____18 = s[i + 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____19 = s[i + 10U];
+      _C[i] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____17,
+          Lib_IntVector_Intrinsics_vec256_xor(uu____18,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____19,
+              Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+    KRML_MAYBE_FOR5(i1,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____20 = _C[(i1 + 4U) % 5U];
+      Lib_IntVector_Intrinsics_vec256 uu____21 = _C[(i1 + 1U) % 5U];
+      Lib_IntVector_Intrinsics_vec256
+      _D =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____20,
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____21,
+              1U),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____21, 63U)));
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        s[i1 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i1 + 5U * i], _D);););
+    Lib_IntVector_Intrinsics_vec256 x = s[1U];
+    Lib_IntVector_Intrinsics_vec256 current = x;
+    for (uint32_t i = 0U; i < 24U; i++)
+    {
+      uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+      uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+      Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+      Lib_IntVector_Intrinsics_vec256 uu____22 = current;
+      s[_Y] =
+        Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____22, r),
+          Lib_IntVector_Intrinsics_vec256_shift_right64(uu____22, 64U - r));
+      current = temp;
+    }
+    KRML_MAYBE_FOR5(i,
+      0U,
+      5U,
+      1U,
+      Lib_IntVector_Intrinsics_vec256 uu____23 = s[0U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____24 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v0 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____23,
+          Lib_IntVector_Intrinsics_vec256_and(uu____24, s[2U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____25 = s[1U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____26 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v1 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____25,
+          Lib_IntVector_Intrinsics_vec256_and(uu____26, s[3U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____27 = s[2U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____28 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v2 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____27,
+          Lib_IntVector_Intrinsics_vec256_and(uu____28, s[4U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____29 = s[3U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____30 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v3 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____29,
+          Lib_IntVector_Intrinsics_vec256_and(uu____30, s[0U + 5U * i]));
+      Lib_IntVector_Intrinsics_vec256 uu____31 = s[4U + 5U * i];
+      Lib_IntVector_Intrinsics_vec256
+      uu____32 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+      Lib_IntVector_Intrinsics_vec256
+      v4 =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____31,
+          Lib_IntVector_Intrinsics_vec256_and(uu____32, s[1U + 5U * i]));
+      s[0U + 5U * i] = v0;
+      s[1U + 5U * i] = v1;
+      s[2U + 5U * i] = v2;
+      s[3U + 5U * i] = v3;
+      s[4U + 5U * i] = v4;);
+    uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i0];
+    Lib_IntVector_Intrinsics_vec256 uu____33 = s[0U];
+    s[0U] =
+      Lib_IntVector_Intrinsics_vec256_xor(uu____33,
+        Lib_IntVector_Intrinsics_vec256_load64(c));
+  }
+  for (uint32_t i0 = 0U; i0 < 64U / rateInBytes; i0++)
+  {
+    uint8_t hbuf[1024U] = { 0U };
+    KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+    memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+    Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+    Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+    Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+    Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+    Lib_IntVector_Intrinsics_vec256
+    v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+    Lib_IntVector_Intrinsics_vec256
+    v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+    Lib_IntVector_Intrinsics_vec256
+    v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256
+    v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+    Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+    Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+    Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+    Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+    Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+    Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+    Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+    Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+    Lib_IntVector_Intrinsics_vec256
+    v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+    Lib_IntVector_Intrinsics_vec256
+    v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+    Lib_IntVector_Intrinsics_vec256
+    v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256
+    v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+    Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+    Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+    Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+    Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+    Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+    Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+    Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+    Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+    Lib_IntVector_Intrinsics_vec256
+    v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+    Lib_IntVector_Intrinsics_vec256
+    v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+    Lib_IntVector_Intrinsics_vec256
+    v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256
+    v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+    Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+    Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+    Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+    Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+    Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+    Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+    Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+    Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+    Lib_IntVector_Intrinsics_vec256
+    v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+    Lib_IntVector_Intrinsics_vec256
+    v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+    Lib_IntVector_Intrinsics_vec256
+    v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256
+    v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+    Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+    Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+    Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+    Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+    Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+    Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+    Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+    Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+    Lib_IntVector_Intrinsics_vec256
+    v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+    Lib_IntVector_Intrinsics_vec256
+    v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+    Lib_IntVector_Intrinsics_vec256
+    v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256
+    v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+    Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+    Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+    Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+    Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+    Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+    Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+    Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+    Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+    Lib_IntVector_Intrinsics_vec256
+    v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+    Lib_IntVector_Intrinsics_vec256
+    v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+    Lib_IntVector_Intrinsics_vec256
+    v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256
+    v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+    Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+    Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+    Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+    Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+    Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+    Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+    Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+    Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+    Lib_IntVector_Intrinsics_vec256
+    v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+    Lib_IntVector_Intrinsics_vec256
+    v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+    Lib_IntVector_Intrinsics_vec256
+    v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256
+    v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+    Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+    Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+    Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+    Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+    Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+    Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+    Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+    Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+    Lib_IntVector_Intrinsics_vec256
+    v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+    Lib_IntVector_Intrinsics_vec256
+    v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+    Lib_IntVector_Intrinsics_vec256
+    v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+    Lib_IntVector_Intrinsics_vec256
+    v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256
+    v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+    Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+    Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+    Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+    Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+    ws[0U] = ws0;
+    ws[1U] = ws1;
+    ws[2U] = ws2;
+    ws[3U] = ws3;
+    ws[4U] = ws4;
+    ws[5U] = ws5;
+    ws[6U] = ws6;
+    ws[7U] = ws7;
+    ws[8U] = ws8;
+    ws[9U] = ws9;
+    ws[10U] = ws10;
+    ws[11U] = ws11;
+    ws[12U] = ws12;
+    ws[13U] = ws13;
+    ws[14U] = ws14;
+    ws[15U] = ws15;
+    ws[16U] = ws16;
+    ws[17U] = ws17;
+    ws[18U] = ws18;
+    ws[19U] = ws19;
+    ws[20U] = ws20;
+    ws[21U] = ws21;
+    ws[22U] = ws22;
+    ws[23U] = ws23;
+    ws[24U] = ws24;
+    ws[25U] = ws25;
+    ws[26U] = ws26;
+    ws[27U] = ws27;
+    ws[28U] = ws28;
+    ws[29U] = ws29;
+    ws[30U] = ws30;
+    ws[31U] = ws31;
+    for (uint32_t i = 0U; i < 32U; i++)
+    {
+      Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+    }
+    for (uint32_t i = 0U; i < rateInBytes / 32U; i++)
+    {
+      uint8_t *b31 = rb.snd.snd.snd;
+      uint8_t *b21 = rb.snd.snd.fst;
+      uint8_t *b11 = rb.snd.fst;
+      uint8_t *b01 = rb.fst;
+      memcpy(b01 + i0 * rateInBytes + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+      memcpy(b11 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+      memcpy(b21 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+      memcpy(b31 + i0 * rateInBytes + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+    }
+    uint32_t rem0 = rateInBytes % 32U;
+    uint32_t j = rateInBytes / 32U;
+    uint8_t *b31 = rb.snd.snd.snd;
+    uint8_t *b21 = rb.snd.snd.fst;
+    uint8_t *b11 = rb.snd.fst;
+    uint8_t *b01 = rb.fst;
+    memcpy(b01 + i0 * rateInBytes + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+    memcpy(b11 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+    memcpy(b21 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+    memcpy(b31 + i0 * rateInBytes + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+    for (uint32_t i1 = 0U; i1 < 24U; i1++)
+    {
+      KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 _C[5U] KRML_POST_ALIGN(32) = { 0U };
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____34 = s[i + 0U];
+        Lib_IntVector_Intrinsics_vec256 uu____35 = s[i + 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____36 = s[i + 10U];
+        _C[i] =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____34,
+            Lib_IntVector_Intrinsics_vec256_xor(uu____35,
+              Lib_IntVector_Intrinsics_vec256_xor(uu____36,
+                Lib_IntVector_Intrinsics_vec256_xor(s[i + 15U], s[i + 20U])))););
+      KRML_MAYBE_FOR5(i2,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____37 = _C[(i2 + 4U) % 5U];
+        Lib_IntVector_Intrinsics_vec256 uu____38 = _C[(i2 + 1U) % 5U];
+        Lib_IntVector_Intrinsics_vec256
+        _D =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____37,
+            Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____38,
+                1U),
+              Lib_IntVector_Intrinsics_vec256_shift_right64(uu____38, 63U)));
+        KRML_MAYBE_FOR5(i,
+          0U,
+          5U,
+          1U,
+          s[i2 + 5U * i] = Lib_IntVector_Intrinsics_vec256_xor(s[i2 + 5U * i], _D);););
+      Lib_IntVector_Intrinsics_vec256 x = s[1U];
+      Lib_IntVector_Intrinsics_vec256 current = x;
+      for (uint32_t i = 0U; i < 24U; i++)
+      {
+        uint32_t _Y = Hacl_Impl_SHA3_Vec_keccak_piln[i];
+        uint32_t r = Hacl_Impl_SHA3_Vec_keccak_rotc[i];
+        Lib_IntVector_Intrinsics_vec256 temp = s[_Y];
+        Lib_IntVector_Intrinsics_vec256 uu____39 = current;
+        s[_Y] =
+          Lib_IntVector_Intrinsics_vec256_or(Lib_IntVector_Intrinsics_vec256_shift_left64(uu____39,
+              r),
+            Lib_IntVector_Intrinsics_vec256_shift_right64(uu____39, 64U - r));
+        current = temp;
+      }
+      KRML_MAYBE_FOR5(i,
+        0U,
+        5U,
+        1U,
+        Lib_IntVector_Intrinsics_vec256 uu____40 = s[0U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____41 = Lib_IntVector_Intrinsics_vec256_lognot(s[1U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v023 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____40,
+            Lib_IntVector_Intrinsics_vec256_and(uu____41, s[2U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____42 = s[1U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____43 = Lib_IntVector_Intrinsics_vec256_lognot(s[2U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v123 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____42,
+            Lib_IntVector_Intrinsics_vec256_and(uu____43, s[3U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____44 = s[2U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____45 = Lib_IntVector_Intrinsics_vec256_lognot(s[3U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v223 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____44,
+            Lib_IntVector_Intrinsics_vec256_and(uu____45, s[4U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____46 = s[3U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____47 = Lib_IntVector_Intrinsics_vec256_lognot(s[4U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v323 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____46,
+            Lib_IntVector_Intrinsics_vec256_and(uu____47, s[0U + 5U * i]));
+        Lib_IntVector_Intrinsics_vec256 uu____48 = s[4U + 5U * i];
+        Lib_IntVector_Intrinsics_vec256
+        uu____49 = Lib_IntVector_Intrinsics_vec256_lognot(s[0U + 5U * i]);
+        Lib_IntVector_Intrinsics_vec256
+        v4 =
+          Lib_IntVector_Intrinsics_vec256_xor(uu____48,
+            Lib_IntVector_Intrinsics_vec256_and(uu____49, s[1U + 5U * i]));
+        s[0U + 5U * i] = v023;
+        s[1U + 5U * i] = v123;
+        s[2U + 5U * i] = v223;
+        s[3U + 5U * i] = v323;
+        s[4U + 5U * i] = v4;);
+      uint64_t c = Hacl_Impl_SHA3_Vec_keccak_rndc[i1];
+      Lib_IntVector_Intrinsics_vec256 uu____50 = s[0U];
+      s[0U] =
+        Lib_IntVector_Intrinsics_vec256_xor(uu____50,
+          Lib_IntVector_Intrinsics_vec256_load64(c));
+    }
+  }
+  uint32_t remOut = 64U % rateInBytes;
+  uint8_t hbuf[1024U] = { 0U };
+  KRML_PRE_ALIGN(32) Lib_IntVector_Intrinsics_vec256 ws[32U] KRML_POST_ALIGN(32) = { 0U };
+  memcpy(ws, s, 25U * sizeof (Lib_IntVector_Intrinsics_vec256));
+  Lib_IntVector_Intrinsics_vec256 v016 = ws[0U];
+  Lib_IntVector_Intrinsics_vec256 v116 = ws[1U];
+  Lib_IntVector_Intrinsics_vec256 v216 = ws[2U];
+  Lib_IntVector_Intrinsics_vec256 v316 = ws[3U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v1_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v016, v116);
+  Lib_IntVector_Intrinsics_vec256
+  v2_15 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v3_15 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v216, v316);
+  Lib_IntVector_Intrinsics_vec256
+  v0__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v1__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_15, v2_15);
+  Lib_IntVector_Intrinsics_vec256
+  v2__15 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256
+  v3__15 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_15, v3_15);
+  Lib_IntVector_Intrinsics_vec256 ws0 = v0__15;
+  Lib_IntVector_Intrinsics_vec256 ws1 = v2__15;
+  Lib_IntVector_Intrinsics_vec256 ws2 = v1__15;
+  Lib_IntVector_Intrinsics_vec256 ws3 = v3__15;
+  Lib_IntVector_Intrinsics_vec256 v017 = ws[4U];
+  Lib_IntVector_Intrinsics_vec256 v117 = ws[5U];
+  Lib_IntVector_Intrinsics_vec256 v217 = ws[6U];
+  Lib_IntVector_Intrinsics_vec256 v317 = ws[7U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v1_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v017, v117);
+  Lib_IntVector_Intrinsics_vec256
+  v2_16 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v3_16 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v217, v317);
+  Lib_IntVector_Intrinsics_vec256
+  v0__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v1__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_16, v2_16);
+  Lib_IntVector_Intrinsics_vec256
+  v2__16 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256
+  v3__16 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_16, v3_16);
+  Lib_IntVector_Intrinsics_vec256 ws4 = v0__16;
+  Lib_IntVector_Intrinsics_vec256 ws5 = v2__16;
+  Lib_IntVector_Intrinsics_vec256 ws6 = v1__16;
+  Lib_IntVector_Intrinsics_vec256 ws7 = v3__16;
+  Lib_IntVector_Intrinsics_vec256 v018 = ws[8U];
+  Lib_IntVector_Intrinsics_vec256 v118 = ws[9U];
+  Lib_IntVector_Intrinsics_vec256 v218 = ws[10U];
+  Lib_IntVector_Intrinsics_vec256 v318 = ws[11U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v1_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v018, v118);
+  Lib_IntVector_Intrinsics_vec256
+  v2_17 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v3_17 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v218, v318);
+  Lib_IntVector_Intrinsics_vec256
+  v0__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v1__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_17, v2_17);
+  Lib_IntVector_Intrinsics_vec256
+  v2__17 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256
+  v3__17 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_17, v3_17);
+  Lib_IntVector_Intrinsics_vec256 ws8 = v0__17;
+  Lib_IntVector_Intrinsics_vec256 ws9 = v2__17;
+  Lib_IntVector_Intrinsics_vec256 ws10 = v1__17;
+  Lib_IntVector_Intrinsics_vec256 ws11 = v3__17;
+  Lib_IntVector_Intrinsics_vec256 v019 = ws[12U];
+  Lib_IntVector_Intrinsics_vec256 v119 = ws[13U];
+  Lib_IntVector_Intrinsics_vec256 v219 = ws[14U];
+  Lib_IntVector_Intrinsics_vec256 v319 = ws[15U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v1_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v019, v119);
+  Lib_IntVector_Intrinsics_vec256
+  v2_18 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v3_18 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v219, v319);
+  Lib_IntVector_Intrinsics_vec256
+  v0__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v1__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_18, v2_18);
+  Lib_IntVector_Intrinsics_vec256
+  v2__18 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256
+  v3__18 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_18, v3_18);
+  Lib_IntVector_Intrinsics_vec256 ws12 = v0__18;
+  Lib_IntVector_Intrinsics_vec256 ws13 = v2__18;
+  Lib_IntVector_Intrinsics_vec256 ws14 = v1__18;
+  Lib_IntVector_Intrinsics_vec256 ws15 = v3__18;
+  Lib_IntVector_Intrinsics_vec256 v020 = ws[16U];
+  Lib_IntVector_Intrinsics_vec256 v120 = ws[17U];
+  Lib_IntVector_Intrinsics_vec256 v220 = ws[18U];
+  Lib_IntVector_Intrinsics_vec256 v320 = ws[19U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v1_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v020, v120);
+  Lib_IntVector_Intrinsics_vec256
+  v2_19 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v3_19 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v220, v320);
+  Lib_IntVector_Intrinsics_vec256
+  v0__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v1__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_19, v2_19);
+  Lib_IntVector_Intrinsics_vec256
+  v2__19 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256
+  v3__19 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_19, v3_19);
+  Lib_IntVector_Intrinsics_vec256 ws16 = v0__19;
+  Lib_IntVector_Intrinsics_vec256 ws17 = v2__19;
+  Lib_IntVector_Intrinsics_vec256 ws18 = v1__19;
+  Lib_IntVector_Intrinsics_vec256 ws19 = v3__19;
+  Lib_IntVector_Intrinsics_vec256 v021 = ws[20U];
+  Lib_IntVector_Intrinsics_vec256 v121 = ws[21U];
+  Lib_IntVector_Intrinsics_vec256 v221 = ws[22U];
+  Lib_IntVector_Intrinsics_vec256 v321 = ws[23U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v1_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v021, v121);
+  Lib_IntVector_Intrinsics_vec256
+  v2_20 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v3_20 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v221, v321);
+  Lib_IntVector_Intrinsics_vec256
+  v0__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v1__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_20, v2_20);
+  Lib_IntVector_Intrinsics_vec256
+  v2__20 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256
+  v3__20 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_20, v3_20);
+  Lib_IntVector_Intrinsics_vec256 ws20 = v0__20;
+  Lib_IntVector_Intrinsics_vec256 ws21 = v2__20;
+  Lib_IntVector_Intrinsics_vec256 ws22 = v1__20;
+  Lib_IntVector_Intrinsics_vec256 ws23 = v3__20;
+  Lib_IntVector_Intrinsics_vec256 v022 = ws[24U];
+  Lib_IntVector_Intrinsics_vec256 v122 = ws[25U];
+  Lib_IntVector_Intrinsics_vec256 v222 = ws[26U];
+  Lib_IntVector_Intrinsics_vec256 v322 = ws[27U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v1_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v022, v122);
+  Lib_IntVector_Intrinsics_vec256
+  v2_21 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v3_21 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v222, v322);
+  Lib_IntVector_Intrinsics_vec256
+  v0__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v1__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_21, v2_21);
+  Lib_IntVector_Intrinsics_vec256
+  v2__21 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256
+  v3__21 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_21, v3_21);
+  Lib_IntVector_Intrinsics_vec256 ws24 = v0__21;
+  Lib_IntVector_Intrinsics_vec256 ws25 = v2__21;
+  Lib_IntVector_Intrinsics_vec256 ws26 = v1__21;
+  Lib_IntVector_Intrinsics_vec256 ws27 = v3__21;
+  Lib_IntVector_Intrinsics_vec256 v0 = ws[28U];
+  Lib_IntVector_Intrinsics_vec256 v1 = ws[29U];
+  Lib_IntVector_Intrinsics_vec256 v2 = ws[30U];
+  Lib_IntVector_Intrinsics_vec256 v3 = ws[31U];
+  Lib_IntVector_Intrinsics_vec256
+  v0_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v1_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v0, v1);
+  Lib_IntVector_Intrinsics_vec256
+  v2_22 = Lib_IntVector_Intrinsics_vec256_interleave_low64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v3_22 = Lib_IntVector_Intrinsics_vec256_interleave_high64(v2, v3);
+  Lib_IntVector_Intrinsics_vec256
+  v0__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v1__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v0_22, v2_22);
+  Lib_IntVector_Intrinsics_vec256
+  v2__22 = Lib_IntVector_Intrinsics_vec256_interleave_low128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256
+  v3__22 = Lib_IntVector_Intrinsics_vec256_interleave_high128(v1_22, v3_22);
+  Lib_IntVector_Intrinsics_vec256 ws28 = v0__22;
+  Lib_IntVector_Intrinsics_vec256 ws29 = v2__22;
+  Lib_IntVector_Intrinsics_vec256 ws30 = v1__22;
+  Lib_IntVector_Intrinsics_vec256 ws31 = v3__22;
+  ws[0U] = ws0;
+  ws[1U] = ws1;
+  ws[2U] = ws2;
+  ws[3U] = ws3;
+  ws[4U] = ws4;
+  ws[5U] = ws5;
+  ws[6U] = ws6;
+  ws[7U] = ws7;
+  ws[8U] = ws8;
+  ws[9U] = ws9;
+  ws[10U] = ws10;
+  ws[11U] = ws11;
+  ws[12U] = ws12;
+  ws[13U] = ws13;
+  ws[14U] = ws14;
+  ws[15U] = ws15;
+  ws[16U] = ws16;
+  ws[17U] = ws17;
+  ws[18U] = ws18;
+  ws[19U] = ws19;
+  ws[20U] = ws20;
+  ws[21U] = ws21;
+  ws[22U] = ws22;
+  ws[23U] = ws23;
+  ws[24U] = ws24;
+  ws[25U] = ws25;
+  ws[26U] = ws26;
+  ws[27U] = ws27;
+  ws[28U] = ws28;
+  ws[29U] = ws29;
+  ws[30U] = ws30;
+  ws[31U] = ws31;
+  for (uint32_t i = 0U; i < 32U; i++)
+  {
+    Lib_IntVector_Intrinsics_vec256_store64_le(hbuf + i * 32U, ws[i]);
+  }
+  for (uint32_t i = 0U; i < remOut / 32U; i++)
+  {
+    uint8_t *b3 = rb.snd.snd.snd;
+    uint8_t *b2 = rb.snd.snd.fst;
+    uint8_t *b1 = rb.snd.fst;
+    uint8_t *b0 = rb.fst;
+    memcpy(b0 + 64U - remOut + i * 32U, hbuf + i * 128U, 32U * sizeof (uint8_t));
+    memcpy(b1 + 64U - remOut + i * 32U, hbuf + i * 128U + 32U, 32U * sizeof (uint8_t));
+    memcpy(b2 + 64U - remOut + i * 32U, hbuf + i * 128U + 64U, 32U * sizeof (uint8_t));
+    memcpy(b3 + 64U - remOut + i * 32U, hbuf + i * 128U + 96U, 32U * sizeof (uint8_t));
+  }
+  uint32_t rem0 = remOut % 32U;
+  uint32_t j = remOut / 32U;
+  uint8_t *b3 = rb.snd.snd.snd;
+  uint8_t *b2 = rb.snd.snd.fst;
+  uint8_t *b1 = rb.snd.fst;
+  uint8_t *b0 = rb.fst;
+  memcpy(b0 + 64U - remOut + j * 32U, hbuf + j * 128U, rem0 * sizeof (uint8_t));
+  memcpy(b1 + 64U - remOut + j * 32U, hbuf + j * 128U + 32U, rem0 * sizeof (uint8_t));
+  memcpy(b2 + 64U - remOut + j * 32U, hbuf + j * 128U + 64U, rem0 * sizeof (uint8_t));
+  memcpy(b3 + 64U - remOut + j * 32U, hbuf + j * 128U + 96U, rem0 * sizeof (uint8_t));
+}
+

--- a/tests/sha3.cc
+++ b/tests/sha3.cc
@@ -12,11 +12,11 @@
 #include <string.h>
 
 #include "Hacl_Hash_SHA3.h"
-#include "Hacl_SHA3_Scalar.h"
+#include "Hacl_Hash_SHA3_Scalar.h"
 #include "hacl-cpu-features.h"
 
 #ifdef HACL_CAN_COMPILE_VEC256
-#include "Hacl_SHA3_Vec256.h"
+#include "Hacl_Hash_SHA3_Simd256.h"
 #endif
 
 #include "config.h"
@@ -178,7 +178,7 @@ TEST(ApiSuite, ApiTest)
 
     uint8_t digest[HACL_HASH_SHA3_256_DIGEST_LENGTH];
 
-    Hacl_SHA3_Scalar_sha3_256(message_size, (uint8_t*)message, digest);
+    Hacl_Hash_SHA3_Scalar_sha3_256(message_size, (uint8_t*)message, digest);
     // ANCHOR_END(example scalar_sha3_256)
 
     bytes expected_digest = from_hex(
@@ -203,7 +203,7 @@ TEST(ApiSuite, ApiTest)
     uint32_t digest_size = 42;
     uint8_t digest[42];
 
-    Hacl_SHA3_Scalar_shake128_hacl(
+    Hacl_Hash_SHA3_Scalar_shake128(
       message_size, (uint8_t*)message, digest_size, digest);
     // ANCHOR_END(example scalar_shake128)
 
@@ -232,7 +232,7 @@ TEST(ApiSuite, ApiTest)
       uint8_t digest2[HACL_HASH_SHA3_256_DIGEST_LENGTH];
       uint8_t digest3[HACL_HASH_SHA3_256_DIGEST_LENGTH];
 
-      Hacl_SHA3_Vec256_sha3_256_vec256(message_size,
+      Hacl_Hash_SHA3_Simd256_sha3_256(message_size,
                                        (uint8_t*)message,
                                        (uint8_t*)message,
                                        (uint8_t*)message,
@@ -283,7 +283,7 @@ TEST(ApiSuite, ApiTest)
       uint8_t digest2[42];
       uint8_t digest3[42];
 
-      Hacl_SHA3_Vec256_shake128_vec256(message_size,
+      Hacl_Hash_SHA3_Simd256_shake128(message_size,
                                        (uint8_t*)message0,
                                        (uint8_t*)message1,
                                        (uint8_t*)message2,
@@ -355,16 +355,16 @@ TEST_P(Sha3KAT, TryKAT)
   {
     bytes digest(test_case.md.size(), 0);
     if (test_case.md.size() == 224 / 8) {
-      Hacl_SHA3_Scalar_sha3_224(
+      Hacl_Hash_SHA3_Scalar_sha3_224(
         test_case.msg.size(), test_case.msg.data(), digest.data());
     } else if (test_case.md.size() == 256 / 8) {
-      Hacl_SHA3_Scalar_sha3_256(
+      Hacl_Hash_SHA3_Scalar_sha3_256(
         test_case.msg.size(), test_case.msg.data(), digest.data());
     } else if (test_case.md.size() == 384 / 8) {
-      Hacl_SHA3_Scalar_sha3_384(
+      Hacl_Hash_SHA3_Scalar_sha3_384(
         test_case.msg.size(), test_case.msg.data(), digest.data());
     } else if (test_case.md.size() == 512 / 8) {
-      Hacl_SHA3_Scalar_sha3_512(
+      Hacl_Hash_SHA3_Scalar_sha3_512(
         test_case.msg.size(), test_case.msg.data(), digest.data());
     }
 
@@ -380,7 +380,7 @@ TEST_P(Sha3KAT, TryKAT)
     bytes digest2(test_case.md.size(), 0);
     bytes digest3(test_case.md.size(), 0);
     if (test_case.md.size() == 224 / 8) {
-      Hacl_SHA3_Vec256_sha3_224_vec256(test_case.msg.size(),
+      Hacl_Hash_SHA3_Simd256_sha3_224(test_case.msg.size(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
@@ -390,7 +390,7 @@ TEST_P(Sha3KAT, TryKAT)
                                        digest2.data(),
                                        digest3.data());
     } else if (test_case.md.size() == 256 / 8) {
-      Hacl_SHA3_Vec256_sha3_256_vec256(test_case.msg.size(),
+      Hacl_Hash_SHA3_Simd256_sha3_256(test_case.msg.size(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
@@ -400,7 +400,7 @@ TEST_P(Sha3KAT, TryKAT)
                                        digest2.data(),
                                        digest3.data());
     } else if (test_case.md.size() == 384 / 8) {
-      Hacl_SHA3_Vec256_sha3_384_vec256(test_case.msg.size(),
+      Hacl_Hash_SHA3_Simd256_sha3_384(test_case.msg.size(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
@@ -410,7 +410,7 @@ TEST_P(Sha3KAT, TryKAT)
                                        digest2.data(),
                                        digest3.data());
     } else if (test_case.md.size() == 512 / 8) {
-      Hacl_SHA3_Vec256_sha3_512_vec256(test_case.msg.size(),
+      Hacl_Hash_SHA3_Simd256_sha3_512(test_case.msg.size(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
@@ -468,7 +468,7 @@ TEST_P(ShakeKAT, TryKAT)
     if (test_case.md.size() == 128 / 8) {
       bytes digest(test_case.md.size(), 128 / 8);
 
-      Hacl_SHA3_Scalar_shake128_hacl(test_case.msg.size(),
+      Hacl_Hash_SHA3_Scalar_shake128(test_case.msg.size(),
                                      test_case.msg.data(),
                                      digest.size(),
                                      digest.data());
@@ -478,7 +478,7 @@ TEST_P(ShakeKAT, TryKAT)
     } else if (test_case.md.size() == 256 / 8) {
       bytes digest(test_case.md.size(), 256 / 8);
 
-      Hacl_SHA3_Scalar_shake256_hacl(test_case.msg.size(),
+      Hacl_Hash_SHA3_Scalar_shake256(test_case.msg.size(),
                                      test_case.msg.data(),
                                      digest.size(),
                                      digest.data());
@@ -497,7 +497,7 @@ TEST_P(ShakeKAT, TryKAT)
       bytes digest2(test_case.md.size(), 128 / 8);
       bytes digest3(test_case.md.size(), 128 / 8);
 
-      Hacl_SHA3_Vec256_shake128_vec256(test_case.msg.size(),
+      Hacl_Hash_SHA3_Simd256_shake128(test_case.msg.size(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
@@ -526,7 +526,7 @@ TEST_P(ShakeKAT, TryKAT)
       bytes digest2(test_case.md.size(), 256 / 8);
       bytes digest3(test_case.md.size(), 256 / 8);
 
-      Hacl_SHA3_Vec256_shake256_vec256(test_case.msg.size(),
+      Hacl_Hash_SHA3_Simd256_shake256(test_case.msg.size(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),
                                        test_case.msg.data(),


### PR DESCRIPTION
This patch uses the new hacl naming convention for SHA3 Scalar and Simd256 functions.

NOTE naming convention is slightly modified to distinguish between scalar and original SHA3 functions until we remove the latter.