### PR TITLE
CI: ensure Python >=3 is installed when building the documentation

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,6 +46,11 @@ jobs:
         run: |
           npm install -g jsdoc
 
+      - name: Setup | Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Setup | Sphinx
         run: |
           cd docs/reference


### PR DESCRIPTION
The workflow to build the documentation is currently flaky.
Pip sometimes fails with the following error:

```
DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.
ERROR: Could not find a version that satisfies the requirement myst-parser (from -r requirements.txt (line 1)) (from versions: none)
ERROR: No matching distribution found for myst-parser (from -r requirements.txt (line 1))
```

Thus it seems that the macos runners sometimes come with Python 2 installed which causes `pip` to fail.
What is weird is that this only happens sometimes, and a re-run of the job usually fixes the issue.

This PR uses the `setup-python` github action to ensure that a recent version of Python is installed.