### PR TITLE
bench against libb2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ include(${PROJECT_SOURCE_DIR}/build/config.cmake)
 # Constants used throughout hacl and the build.
 include(config/constants.cmake)
 
+# for libb2
+include(FindPkgConfig)
+
 # Set system processor to 32-bit.
 # Note that this only works on intel for now.
 if(CMAKE_C_FLAGS MATCHES ".*-m32.*")
@@ -524,6 +527,14 @@ if(ENABLE_BENCHMARKS)
         else()
             target_compile_definitions(${BENCH_NAME} PUBLIC NO_OPENSSL)
         endif(ENABLE_OPENSSL_BENCHMARKS)
+
+        if(ENABLE_LIBB2_BENCHMARKS)
+          pkg_check_modules (LIBB2 REQUIRED libb2)
+          target_link_libraries(${BENCH_NAME} PRIVATE ${LIBB2_LIBRARIES})
+          target_link_directories(${BENCH_NAME} PRIVATE ${LIBB2_LIBRARY_DIRS})
+          target_include_directories(${BENCH_NAME} PUBLIC ${LIBB2_INCLUDE_DIRS})
+          target_compile_options(${BENCH_NAME} PUBLIC ${LIBB2_CFLAGS_OTHER})
+        endif(ENABLE_LIBB2_BENCHMARKS)
 
         if(ENABLE_LIBTOMCRYPT_BENCHMARKS)
             if(DEFINED ENV{LIBTOMCRYPT_HOME})

--- a/benchmarks/blake.cc
+++ b/benchmarks/blake.cc
@@ -97,6 +97,21 @@ BENCHMARK_CAPTURE(OpenSSL_hash_oneshot,
   ->Setup(DoSetup);
 #endif
 
+#ifndef NO_LIBB2
+#include <blake2.h>
+
+static void
+libb2_blake2b_oneshot(benchmark::State& state)
+{
+  bytes input(state.range(0), 0xAB);
+
+  for (auto _ : state)
+    blake2b(digest2b.data(), (const void*)input.data(), NULL, digest2b.size(), input.size(), 0);
+}
+
+BENCHMARK(libb2_blake2b_oneshot)->Setup(DoSetup);
+#endif
+
 // -----------------------------------------------------------------------------
 
 static void
@@ -148,6 +163,19 @@ OpenSSL_blake2b_oneshot_keyed(benchmark::State& state)
 }
 
 BENCHMARK(OpenSSL_blake2b_oneshot_keyed)->Setup(DoSetup);
+#endif
+
+#ifndef NO_LIBB2
+#include <blake2.h>
+
+static void
+libb2_blake2b_oneshot_keyed(benchmark::State& state)
+{
+  for (auto _ : state)
+    blake2b(digest2b.data(), (const void*)input.data(), (const void*)key.data(), digest2b.size(), input.size(), key.size());
+}
+
+BENCHMARK(libb2_blake2b_oneshot_keyed)->Setup(DoSetup);
 #endif
 
 
@@ -209,6 +237,21 @@ BENCHMARK_CAPTURE(OpenSSL_hash_oneshot,
   ->Setup(DoSetup);
 #endif
 
+#ifndef NO_LIBB2
+#include <blake2.h>
+
+static void
+libb2_blake2s_oneshot(benchmark::State& state)
+{
+  bytes input(state.range(0), 0xAB);
+
+  for (auto _ : state)
+    blake2s(digest2s.data(), (const void*)input.data(), NULL, digest2s.size(), input.size(), 0);
+}
+
+BENCHMARK(libb2_blake2s_oneshot)->Setup(DoSetup);
+#endif
+
 // -----------------------------------------------------------------------------
 
 static void
@@ -261,6 +304,20 @@ OpenSSL_blake2s_oneshot_keyed(benchmark::State& state)
 
 BENCHMARK(OpenSSL_blake2s_oneshot_keyed)->Setup(DoSetup);
 #endif
+
+#ifndef NO_LIBB2
+#include <blake2.h>
+
+static void
+libb2_blake2s_oneshot_keyed(benchmark::State& state)
+{
+  for (auto _ : state)
+    blake2s(digest2s.data(), (const void*)input.data(), (const void*)key.data(), digest2s.size(), input.size(), key.size());
+}
+
+BENCHMARK(libb2_blake2s_oneshot_keyed)->Setup(DoSetup);
+#endif
+
 
 // -----------------------------------------------------------------------------
 

--- a/mach
+++ b/mach
@@ -96,6 +96,11 @@ def install(args):
             action="store_true",
         ),
         argument(
+            "--no-libb2",
+            help="Don't build and run libb2 benchmarks.",
+            action="store_true",
+        ),
+        argument(
             "--libtomcrypt",
             help="Build and run LibTomCrypt benchmarks.",
             action="store_true",
@@ -340,6 +345,8 @@ def build(args):
             )
             exit(1)
         cmake_args.append("-DENABLE_BENCHMARKS=ON")
+        if not args.no_libb2:
+            cmake_args.append("-DENABLE_LIBB2_BENCHMARKS=ON")
         if not args.no_openssl:
             cmake_args.append("-DENABLE_OPENSSL_BENCHMARKS=ON")
             if platform.system() == "Darwin":


### PR DESCRIPTION
As part of https://github.com/python/cpython/issues/99108 I would like to gather some data as to the relative performance of HACL*'s blake2 implementation against libb2.

To that effect, I added cmake voodoo, and a few benchmarks.

Sadly, I'm getting a segfault, and I can't debug because I don't know how to build the benchmarks with debugging info.

@franziskuskiefer can you take a look at tell me i) whether you see any issue and/or ii) how to build benchmarks in debug mode so that I can at least try to figure out what's going on?

thanks!