### PR TITLE
Fix MSVC+CPP issue with including eurydice_glue.h w/ C++17

### DIFF
--- a/libcrux/include/eurydice_glue.h
+++ b/libcrux/include/eurydice_glue.h
@@ -123,11 +123,11 @@ typedef struct {
 // use it to peform manual offset computations rather than going through the macros.
 static inline Eurydice_slice chunk_next(Eurydice_chunks *chunks, size_t element_size) {
   size_t chunk_size = chunks->slice.len >= chunks->chunk_size ? chunks->chunk_size : chunks->slice.len;
-  Eurydice_slice curr_chunk = ((Eurydice_slice) { .ptr = chunks->slice.ptr, .len = chunk_size });
-  chunks->slice = ((Eurydice_slice) {
-    .ptr = (char *)(chunks->slice.ptr) + chunk_size * element_size,
-    .len = chunks->slice.len - chunk_size
-  });
+  Eurydice_slice curr_chunk;
+  curr_chunk.ptr = chunks->slice.ptr;
+  curr_chunk.len = chunk_size;
+  chunks->slice.ptr = (char *)(chunks->slice.ptr) + chunk_size * element_size;
+  chunks->slice.len = chunks->slice.len - chunk_size;
   return curr_chunk;
 }
 


### PR DESCRIPTION
+ Without this MSVC generates error C7555 when eurydice_glue.h is included in any C++ source (https://godbolt.org/z/EqcvcG3Yj)