### PR TITLE
Unpin breathe version, force more recent sphinx version

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Setup | System
         run: |
-          brew install doxygen sphinx-doc gmp ninja node
+          brew install doxygen gmp ninja node
           pip install --upgrade pip
 
       - name: Setup | OCaml | 1/2

--- a/docs/reference/conf.py
+++ b/docs/reference/conf.py
@@ -24,7 +24,7 @@ copyright = '2022, Cryspen'
 author = 'Cryspen'
 
 # The full version, including alpha/beta/rc tags
-release = "5.0.2"
+#release = ""
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/reference/requirements.txt
+++ b/docs/reference/requirements.txt
@@ -1,3 +1,5 @@
+sphinx >= 5.0.0
+
 myst-parser
 sphinx-multiversion
 
@@ -5,4 +7,4 @@ pydata-sphinx-theme
 sphinx-book-theme
 
 sphinx-tabs
-breathe==4.33.1
+breathe


### PR DESCRIPTION
The doc workflow is currently broken because of the following error message 
```
Sphinx version error:
The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0; it therefore cannot be built with this version.
```

To fix this, this PR forces the Sphinx version to be at least 5.0.0, and installs it through pip instead of brew to have more flexibility on the sphinx version.
Note, this required unpinning the version of breathe, which was done in #241 because of breakages due to breathe updates. The latest version of breathe seems fixed, so this might not be needed anymore.