### PR TITLE
Fix implicit declaration of 'explicit_memset' for NetBSD in Lib_Memzero0.c

### DIFF
--- a/src/Lib_Memzero0.c
+++ b/src/Lib_Memzero0.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #endif
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__NetBSD__)
 #include <strings.h>
 #endif
 


### PR DESCRIPTION
I am currently working on building CPython on NetBSD and encountered an error with HACL. After investigating, I found that the issue arises from [here](https://github.com/python/cpython/issues/123718). I have implemented a [fix](https://github.com/python/cpython/pull/123719/files) in the code. I thought it would be useful to send a pull request to the main repository to fix this issue.