### PR TITLE
OCaml API: bump opam package version to 0.7.2

### DIFF
--- a/ocaml/META
+++ b/ocaml/META
@@ -1,5 +1,5 @@
 name="hacl-star-raw"
-version="0.7.1"
+version="0.7.2"
 description="EverCrypt with Ctypes bindings"
 requires="ctypes ctypes.stubs"
 archive(native)="ocamlevercrypt.cmxa"

--- a/ocaml/hacl-star-raw.opam
+++ b/ocaml/hacl-star-raw.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "hacl-star-raw"
-version: "0.7.1"
+version: "0.7.2"
 synopsis: "Auto-generated low-level OCaml bindings for EverCrypt/HACL*"
 description: """
 This package contains a snapshot of the EverCrypt crypto provider and
@@ -24,10 +24,10 @@ depends: [
 conflicts: [
   "ocaml-option-bytecode-only"
 ]
-available: [
-  arch != "ppc64" & arch != "ppc32" & arch != "arm32" &
-  (os = "freebsd" | os-family != "bsd")
-]
+available:
+  arch != "ppc64" & arch != "ppc32" & arch != "arm32" & arch != "riscv64" &
+  os-family != "windows" &
+  os-family != "bsd"
 build: [
   [make "-C" "hacl-star-raw" "build-c" "-j" jobs]
   [make "-C" "hacl-star-raw" "build-bindings" "-j" jobs]

--- a/ocaml/hacl-star/CHANGES.md
+++ b/ocaml/hacl-star/CHANGES.md
@@ -1,6 +1,9 @@
 ## 0.8.0 (Unreleased)
 - API changes for all hash functions
 
+## 0.7.2
+- Compatibility with newer ctypes versions (#421)
+
 ## 0.7.1
 - Significantly faster P-256 signature verification
 - Added SHA-3 to EverCrypt hashing interface

--- a/ocaml/hacl-star/hacl-star.opam
+++ b/ocaml/hacl-star/hacl-star.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "hacl-star"
-version: "0.7.1"
+version: "0.7.2"
 synopsis: "OCaml API for EverCrypt/HACL*"
 description: """
 Documentation for this library can be found
@@ -18,14 +18,11 @@ depends: [
   "hacl-star-raw" {= version}
   "zarith"
   "cppo" {build}
-  "alcotest" {with-test & >= "1.1.0"}
+  "alcotest" {with-test & >= "1.8.0"}
   "qcheck-core" {with-test & >= "0.20"}
   "secp256k1-internal" {with-test}
   "cstruct" {with-test}
   "odoc" {with-doc}
-]
-available: [
-  os = "freebsd" | os-family != "bsd"
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
Bumps version and syncs opam files with those published in the latest release (https://github.com/ocaml/opam-repository/pull/26619)